### PR TITLE
✨ 개인정보 복호화 로직 추가

### DIFF
--- a/src/main/java/OneQ/OnSurvey/domain/member/service/MemberModifyService.java
+++ b/src/main/java/OneQ/OnSurvey/domain/member/service/MemberModifyService.java
@@ -4,7 +4,7 @@ import OneQ.OnSurvey.domain.member.Member;
 import OneQ.OnSurvey.domain.member.repository.MemberRepository;
 import OneQ.OnSurvey.domain.member.value.MemberStatus;
 import OneQ.OnSurvey.domain.member.value.Role;
-import OneQ.OnSurvey.global.infra.toss.dto.LoginMeResponse;
+import OneQ.OnSurvey.global.infra.toss.dto.DecryptedLoginMeResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,32 +17,32 @@ public class MemberModifyService implements MemberUpdater, MemberDeleter {
     private final MemberRepository memberRepository;
 
     @Override
-    public Member upsertMember(LoginMeResponse.Success loginMe) {
-        return memberRepository.findMemberByUserKey(loginMe.userKey())
+    public void upsertMember(DecryptedLoginMeResponse decryptedLoginMeResponse) {
+        memberRepository.findMemberByUserKey(decryptedLoginMeResponse.userKey())
                 .map(existing -> {
                     existing.update(
-                            loginMe.name(),
-                            loginMe.phone(),
-                            loginMe.birthday(),
-                            loginMe.email(),
+                            decryptedLoginMeResponse.name(),
+                            decryptedLoginMeResponse.phone(),
+                            decryptedLoginMeResponse.birthday(),
+                            decryptedLoginMeResponse.email(),
                             MemberStatus.ACTIVE
                     );
 
-                    existing.updateAgreePolicy(loginMe.agreedTerms());
+                    existing.updateAgreePolicy(decryptedLoginMeResponse.agreedTerms());
                     return existing;
                 })
                 .orElseGet(() -> {
                     Member newMember = Member.createMember(
-                            loginMe.userKey(),
-                            loginMe.name(),
-                            loginMe.phone(),
-                            loginMe.birthday(),
-                            loginMe.email(),
+                            decryptedLoginMeResponse.userKey(),
+                            decryptedLoginMeResponse.name(),
+                            decryptedLoginMeResponse.phone(),
+                            decryptedLoginMeResponse.birthday(),
+                            decryptedLoginMeResponse.email(),
                             Role.ROLE_MEMBER,
                             MemberStatus.ACTIVE
                     );
 
-                    newMember.updateAgreePolicy(loginMe.agreedTerms());
+                    newMember.updateAgreePolicy(decryptedLoginMeResponse.agreedTerms());
                     return memberRepository.save(newMember);
                 });
     }

--- a/src/main/java/OneQ/OnSurvey/domain/member/service/MemberUpdater.java
+++ b/src/main/java/OneQ/OnSurvey/domain/member/service/MemberUpdater.java
@@ -1,9 +1,9 @@
 package OneQ.OnSurvey.domain.member.service;
 
 import OneQ.OnSurvey.domain.member.Member;
-import OneQ.OnSurvey.global.infra.toss.dto.LoginMeResponse;
+import OneQ.OnSurvey.global.infra.toss.dto.DecryptedLoginMeResponse;
 
 public interface MemberUpdater {
-    Member upsertMember(LoginMeResponse.Success loginMe);
+    void upsertMember(DecryptedLoginMeResponse decryptedLoginMeResponse);
     void changeMemberStatusTossConnectOut(Member member);
 }

--- a/src/main/java/OneQ/OnSurvey/global/infra/toss/TossErrorCode.java
+++ b/src/main/java/OneQ/OnSurvey/global/infra/toss/TossErrorCode.java
@@ -11,7 +11,8 @@ public enum TossErrorCode implements ApiErrorCode {
 
     TOSS_ACCESS_TOKEN_ERROR("TOSS_001", "TOSS 토큰 발행 중 에러가 발생했습니다.", HttpStatus.BAD_REQUEST),
     TOSS_GET_USER_INFO_ERROR("TOSS_002", "TOSS 유저 정보 가져오기 중 에러가 발생했습니다.", HttpStatus.BAD_REQUEST),
-    INVALID_REFERRER("TOSS_WITHDRAWAL_001", "유효하지 않은 referrer입니다.", HttpStatus.BAD_REQUEST),
+    TOSS_DECRYPT_ERROR("TOSS_003", "유저 정보 복호화에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    INVALID_REFERRER("TOSS_WITHDRAWAL_001", "유효하지 않은 referrer 입니다.", HttpStatus.BAD_REQUEST),
     TOSS_API_CONNECTION_ERROR("TOSS_500", "그 밖에 토스 api를 연동하는 과정에서 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
 
     private final String errorCode;

--- a/src/main/java/OneQ/OnSurvey/global/infra/toss/dto/DecryptedLoginMeResponse.java
+++ b/src/main/java/OneQ/OnSurvey/global/infra/toss/dto/DecryptedLoginMeResponse.java
@@ -1,0 +1,18 @@
+package OneQ.OnSurvey.global.infra.toss.dto;
+
+import java.util.List;
+
+public record DecryptedLoginMeResponse(
+        long userKey,
+        String scope,
+        List<String> agreedTerms,
+        String policy,
+        String certTxId,
+        String name,
+        String phone,
+        String birthday,
+        String gender,
+        String nationality,
+        String email
+) {
+}

--- a/src/main/java/OneQ/OnSurvey/global/infra/toss/service/TossAuthService.java
+++ b/src/main/java/OneQ/OnSurvey/global/infra/toss/service/TossAuthService.java
@@ -7,6 +7,7 @@ import OneQ.OnSurvey.global.auth.token.service.BlackListService;
 import OneQ.OnSurvey.global.auth.utils.JWTUtil;
 import OneQ.OnSurvey.global.exception.CustomException;
 import OneQ.OnSurvey.global.infra.toss.adapter.TossApiClient;
+import OneQ.OnSurvey.global.infra.toss.dto.DecryptedLoginMeResponse;
 import OneQ.OnSurvey.global.infra.toss.dto.LoginMeResponse;
 import OneQ.OnSurvey.global.infra.toss.dto.ReissueRequest;
 import OneQ.OnSurvey.global.infra.toss.dto.TossLoginRequest;
@@ -25,6 +26,7 @@ import java.time.Duration;
 
 import static OneQ.OnSurvey.global.auth.AuthErrorCode.INVALID_REFRESH_TOKEN;
 import static OneQ.OnSurvey.global.infra.toss.TossErrorCode.TOSS_API_CONNECTION_ERROR;
+import static OneQ.OnSurvey.global.infra.toss.TossErrorCode.TOSS_DECRYPT_ERROR;
 
 @Service
 @RequiredArgsConstructor
@@ -54,14 +56,17 @@ public class TossAuthService {
     private final JWTUtil jwtUtil;
     private final TokenStore tokenStore;
     private final BlackListService blacklistService;
+    private final TossMemberInfoDecryptService tossMemberInfoDecryptService;
 
     public Boolean createAccessAndRefreshToken(TossLoginRequest tossLoginRequest, HttpServletResponse response) {
-        // 토스 액세스 토큰 발급
+
         LoginMeResponse.Success loginMeResponse = getTossUserInfo(tossLoginRequest);
 
-        memberModifyService.upsertMember(loginMeResponse);
+        DecryptedLoginMeResponse decryptedLoginResponse = decryptLoginMeOrThrow(loginMeResponse);
 
-        issueTokensToResponse(loginMeResponse.userKey(), response);
+        memberModifyService.upsertMember(decryptedLoginResponse);
+
+        issueTokensToResponse(decryptedLoginResponse.userKey(), response);
 
         return true;
     }
@@ -106,6 +111,15 @@ public class TossAuthService {
         } catch (Exception e) {
             log.error("[TossAuthService Error] : Toss Access Token 발급 중 오류가 발생했습니다.", e);
             throw new CustomException(TOSS_API_CONNECTION_ERROR);
+        }
+    }
+
+    private DecryptedLoginMeResponse decryptLoginMeOrThrow(LoginMeResponse.Success loginMeResponse) {
+        try {
+            return tossMemberInfoDecryptService.decryptResponse(loginMeResponse);
+        } catch (Exception e) {
+            log.error("[TossAuthService Error] 유저 정보 복호화 실패", e);
+            throw new CustomException(TOSS_DECRYPT_ERROR);
         }
     }
 

--- a/src/main/java/OneQ/OnSurvey/global/infra/toss/service/TossMemberInfoDecryptService.java
+++ b/src/main/java/OneQ/OnSurvey/global/infra/toss/service/TossMemberInfoDecryptService.java
@@ -1,0 +1,76 @@
+package OneQ.OnSurvey.global.infra.toss.service;
+
+import OneQ.OnSurvey.global.infra.toss.dto.DecryptedLoginMeResponse;
+import OneQ.OnSurvey.global.infra.toss.dto.LoginMeResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.util.Base64;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TossMemberInfoDecryptService {
+
+    @Value("${toss.decrypt.key}")
+    private String base64EncodedAesKey;
+
+    @Value("${toss.decrypt.aad}")
+    private String aad;
+
+    private String decrypt(
+            String encryptedText
+    ) throws Exception {
+        final int IV_LENGTH = 12;
+        byte[] decoded = Base64.getDecoder().decode(encryptedText);
+        Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+        byte[] keyByteArray = Base64.getDecoder().decode(base64EncodedAesKey);
+        SecretKeySpec key = new SecretKeySpec(keyByteArray, "AES");
+        byte[] iv = new byte[IV_LENGTH];
+        System.arraycopy(decoded, 0, iv, 0, IV_LENGTH);
+        GCMParameterSpec nonceSpec = new GCMParameterSpec(16 * Byte.SIZE, iv);
+
+        cipher.init(Cipher.DECRYPT_MODE, key, nonceSpec);
+        cipher.updateAAD(aad.getBytes());
+
+        byte[] decrypted = cipher.doFinal(decoded, IV_LENGTH, decoded.length - IV_LENGTH);
+        return new String(decrypted);
+    }
+
+    public DecryptedLoginMeResponse decryptResponse(LoginMeResponse.Success enc) throws Exception {
+
+        // 각 필드 복호화 (null 방지)
+        String name = decryptSafe(enc.name());
+        String phone = decryptSafe(enc.phone());
+        String birthday = decryptSafe(enc.birthday());
+        String gender = decryptSafe(enc.gender());
+        String nationality = decryptSafe(enc.nationality());
+        String email = decryptSafe(enc.email());
+
+        return new DecryptedLoginMeResponse(
+             enc.userKey(),
+             enc.scope(),
+             enc.agreedTerms(),
+             enc.policy(),
+             enc.certTxId(),
+             name,
+             phone,
+             birthday,
+             gender,
+             nationality,
+             email
+        );
+    }
+
+    private String decryptSafe(String encoded) throws Exception {
+        if (encoded == null || encoded.isBlank()) {
+            return encoded;
+        }
+        return decrypt(encoded);
+    }
+}


### PR DESCRIPTION
### ✨ Related Issue
- https://linear.app/on-survey/issue/ON-81/%EA%B0%9C%EC%9D%B8%EC%A0%95%EB%B3%B4-%EB%B3%B5%ED%98%B8%ED%99%94-%EB%A1%9C%EC%A7%81-%EC%B6%94%EA%B0%80
---

### 📌 Task Details
- [x] 복호화 키 발급
- [x] yml에 내용 추가
- [x] 복호화 로직 작성

---

### 💬 Review Requirements (Optional)
- secret manager로 관리하려 했으나 NCP에서 적용 방법이 AWS와 달라서 우선 yml에 작성했습니다. 나중에 디벨롭 되면 secret manager로 이관할게요 !
