### PR TITLE
✨ OMF-146 프로모션 PENDING 상태 재조회

### DIFF
--- a/src/main/java/OneQ/OnSurvey/global/promotion/application/PromotionRecheckService.java
+++ b/src/main/java/OneQ/OnSurvey/global/promotion/application/PromotionRecheckService.java
@@ -7,6 +7,7 @@ import OneQ.OnSurvey.global.promotion.port.out.PromotionGrantRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
@@ -25,6 +26,15 @@ public class PromotionRecheckService {
 
     @Value("${toss.api.promotion.code}")
     private String promotionCode;
+
+    @Value("${toss.api.promotion.recheck.scheduler.limit}")
+    private int schedulerLimit;
+
+    @Scheduled(fixedDelayString = "${toss.api.promotion.recheck.scheduler.delay-ms}")
+    public void scheduledRecheckPending() {
+        log.info("[PROMO-SCHEDULER] 스케줄러 실행");
+        recheckPending(schedulerLimit);
+    }
 
     public PromotionRecheckPendingResponse recheckPending(int limit) {
         List<PromotionGrant> pendings = promotionGrantRepository.findPendingWithExecKey(limit);

--- a/src/main/java/OneQ/OnSurvey/global/promotion/application/PromotionRecheckService.java
+++ b/src/main/java/OneQ/OnSurvey/global/promotion/application/PromotionRecheckService.java
@@ -34,6 +34,11 @@ public class PromotionRecheckService {
     public void scheduledRecheckPending() {
         log.info("[PROMO-SCHEDULER] 스케줄러 실행");
         recheckPending(schedulerLimit);
+        try {
+            recheckPending(schedulerLimit);
+        } catch (Exception e) {
+            log.error("[PROMO-SCHEDULER] 스케줄러 실행 중 오류 발생", e);
+        }
     }
 
     public PromotionRecheckPendingResponse recheckPending(int limit) {


### PR DESCRIPTION
### ✨ Related Issue
- [OMF-146](https://onsurvey.atlassian.net/browse/OMF-146)
---

### 📌 Task Details
- [x] 수동으로 호출하던 promotion 상태 recheck API에 스케줄러 설정

---

### 💬 Review Requirements (Optional)
- 스케줄러 호출하는 설정 yml에 추가해뒀습니다
- 10분에 10회씩 조회하도록 해뒀는데, 상황에 따라 조정하면 될듯 해요



[OMF-146]: https://onsurvey.atlassian.net/browse/OMF-146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 프로모션 재확인 기능의 정기적 자동 실행 스케줄링이 추가되었습니다.
* 설정을 통해 재확인 주기 및 처리 건수 한도를 제어할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->