### PR TITLE
♻️ OMF-190 설문 등록 Discord 알림 구체화

### DIFF
--- a/src/main/java/OneQ/OnSurvey/domain/survey/service/command/SurveyCommandService.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/service/command/SurveyCommandService.java
@@ -309,7 +309,8 @@ public class SurveyCommandService implements SurveyCommand {
         applySurveyRuntimeCache(surveyId, userKey, dueCount, deadline);
 
         SurveySubmittedAlert alert = new SurveySubmittedAlert(
-                userKey, surveyId, survey.getTitle(), totalCoin, info.getDueCount()
+                userKey, surveyId, survey.getTitle(), totalCoin, info.getDueCount(),
+                survey.getDeadline(), survey.getIsFree(), info.getGender(), info.getAges().stream().toList()
         );
         afterCommitExecutor.run(() -> alertNotifier.sendSurveySubmittedAsync(alert));
 

--- a/src/main/java/OneQ/OnSurvey/global/infra/discord/DiscordAlarmService.java
+++ b/src/main/java/OneQ/OnSurvey/global/infra/discord/DiscordAlarmService.java
@@ -83,7 +83,11 @@ public class DiscordAlarmService {
                         "• surveyId: `" + a.surveyId() + "`\n" +
                         "• title: `" + safe(a.title()) + "`\n" +
                         "• totalCoin: `" + a.totalCoin() + "`\n" +
-                        "• dueCount: `" + a.dueCount() + "`\n";
+                        "• dueCount: `" + a.dueCount() + "`\n" +
+                        "• deadline: `" + a.deadline() + "`\n" +
+                        "• isFree: `" + a.isFree() + "`\n" +
+                        "• gender: `" + a.gender() + "`\n" +
+                        "• ages: `" + a.ages() + "`\n";
 
         post(url, title, desc);
     }
@@ -141,7 +145,7 @@ public class DiscordAlarmService {
 
         if (stack.length() > budget) {
             int sliceBudget = Math.max(0, budget - TRUNC_SUFFIX.length());
-            stack = stack.substring(0, Math.max(0, sliceBudget));
+            stack = stack.substring(0, sliceBudget);
             truncated = true;
         }
 

--- a/src/main/java/OneQ/OnSurvey/global/infra/discord/notifier/dto/SurveySubmittedAlert.java
+++ b/src/main/java/OneQ/OnSurvey/global/infra/discord/notifier/dto/SurveySubmittedAlert.java
@@ -1,9 +1,19 @@
 package OneQ.OnSurvey.global.infra.discord.notifier.dto;
 
+import OneQ.OnSurvey.domain.survey.model.AgeRange;
+import OneQ.OnSurvey.domain.survey.model.Gender;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
 public record SurveySubmittedAlert(
         long userKey,
         long surveyId,
         String title,
         long totalCoin,
-        Integer dueCount
+        Integer dueCount,
+        LocalDateTime deadline,
+        Boolean isFree,
+        Gender gender,
+        List<AgeRange> ages
 ) {}


### PR DESCRIPTION
### ✨ Related Issue
- [OMF-190](https://onsurvey.atlassian.net/browse/OMF-190)
---

### 📌 Task Details
- [x] 디스코드 알림만으로 등록된 설문의 정보를 확인할 수 있도록 필드 추가
  - 인원수, 마감일, 유료 설문 여부, 세그먼트(성별, 나이) 정보
 
---

### 💬 Review Requirements (Optional)



[OMF-190]: https://onsurvey.atlassian.net/browse/OMF-190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선사항**
  * 설문 제출 알림이 더욱 상세해졌습니다. 마감일, 무료 여부, 사용자의 성별, 연령대 정보가 알림에 포함되어 더 풍부한 정보를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->