### PR TITLE
🐛 OMF-208 응답 조회에서 복수 응답 가능한 문항에 대해 응답자 수 많게 뜨는 문제 해결

### DIFF
--- a/src/main/java/OneQ/OnSurvey/domain/participation/repository/answer/AnswerRepository.java
+++ b/src/main/java/OneQ/OnSurvey/domain/participation/repository/answer/AnswerRepository.java
@@ -33,4 +33,11 @@ public interface AnswerRepository<E> {
     ) {
         return getAnswersByQuestionIds(questionIds);
     }
+
+    default List<AnswerStats> getRespondentCountsByQuestionIds(
+            List<Long> questionIds,
+            SurveyResponseFilterCondition filter
+    ) {
+        return List.of();
+    }
 }

--- a/src/main/java/OneQ/OnSurvey/domain/participation/repository/answer/QuestionAnswerRepositoryImpl.java
+++ b/src/main/java/OneQ/OnSurvey/domain/participation/repository/answer/QuestionAnswerRepositoryImpl.java
@@ -127,6 +127,37 @@ public class QuestionAnswerRepositoryImpl extends AbstractAnswerRepository<Quest
     }
 
     @Override
+    public List<AnswerStats> getRespondentCountsByQuestionIds(
+            List<Long> questionIds,
+            SurveyResponseFilterCondition filter
+    ) {
+        if (questionIds == null || questionIds.isEmpty()) {
+            return List.of();
+        }
+
+        SurveyResponseFilterCondition effective =
+                (filter == null ? SurveyResponseFilterCondition.empty() : filter);
+
+        return jpaQueryFactory
+                .select(Projections.constructor(
+                        AnswerStats.class,
+                        questionAnswer.questionId,
+                        Expressions.nullExpression(String.class),
+                        questionAnswer.memberId.countDistinct()
+                ))
+                .from(questionAnswer)
+                .join(member).on(member.id.eq(questionAnswer.memberId))
+                .where(
+                        questionAnswer.questionId.in(questionIds),
+                        buildAgeCondition(member.birthDay, effective.ages()),
+                        buildGenderCondition(member.gender, effective.genders()),
+                        buildResidenceCondition(member.residence, effective.residences())
+                )
+                .groupBy(questionAnswer.questionId)
+                .fetch();
+    }
+
+    @Override
     public void deleteAllByIds(Collection<Long> answerIds) {
         jpaQueryFactory.delete(questionAnswer)
             .where(questionAnswer.answerId.in(answerIds))

--- a/src/main/java/OneQ/OnSurvey/domain/participation/service/answer/QuestionAnswerQueryService.java
+++ b/src/main/java/OneQ/OnSurvey/domain/participation/service/answer/QuestionAnswerQueryService.java
@@ -54,6 +54,18 @@ public class QuestionAnswerQueryService extends AnswerQueryService<QuestionAnswe
         log.info("[QUESTION_ANSWER_SERVICE] 응답을 조회할 문항 IDs - 주관식: {}, 비주관식: {}",
                 textQuestionIdList, nonTextQuestionIdList);
 
+        List<Long> allQuestionIdList = detailInfoList.stream()
+                .map(SurveyManagementDetailResponse.DetailInfo::getQuestionId)
+                .toList();
+
+        List<AnswerStats> respondentCountStats = answerRepository.getRespondentCountsByQuestionIds(allQuestionIdList, filter);
+        Map<Long, Long> respondentCountMap = respondentCountStats.stream()
+                .collect(Collectors.toMap(AnswerStats::getQuestionId, AnswerStats::getCount));
+
+        detailInfoList.forEach(detailInfo ->
+                detailInfo.setRespondentCount(respondentCountMap.getOrDefault(detailInfo.getQuestionId(), 0L))
+        );
+
         List<AnswerStats> nonTextAnswerStats = nonTextQuestionIdList.isEmpty()
                 ? List.of()
                 : answerRepository.getAggregatedAnswersByQuestionIds(nonTextQuestionIdList, filter);

--- a/src/main/java/OneQ/OnSurvey/domain/survey/model/response/SurveyManagementDetailResponse.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/model/response/SurveyManagementDetailResponse.java
@@ -37,6 +37,10 @@ public class SurveyManagementDetailResponse {
         private final Integer section;
 
         @Setter
+        @Schema(description = "문항 응답자 수 (복수 응답 문항의 경우 선택 횟수가 아닌 실제 응답한 인원 수)")
+        private Long respondentCount;
+
+        @Setter
         @Schema(
             description = "(객관식, 평가형, NPS) 선택값 별 응답 집계",
             example = """ 


### PR DESCRIPTION
### ✨ Related Issue
- [OMF-208](https://onsurvey.atlassian.net/browse/OMF-208)

---

### 📌 Task Details
- [x] 복수 응답이 가능한 문항에 대해 응답 수가 많아지는 현상 발생해 기존 answerMap 수를 계산하는 방식에서 서버에서 응답자 수(`respondentCount`)를 response에 추가하는 방식으로 변경

---

### 💬 Review Requirements (Optional)



[OMF-208]: https://onsurvey.atlassian.net/browse/OMF-208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 설문 조사 질문별 응답자 수 추적 기능 추가
  * 응답자 필터링 조건(나이, 성별, 거주지)을 적용한 질문별 응답자 수 조회 기능 구현
  * 설문 관리 상세 정보에 질문별 응답자 수 표시

<!-- end of auto-generated comment: release notes by coderabbit.ai -->