### PR TITLE
🐛 OMF-248 완료된 response에 대해서면 csv 추출

### DIFF
--- a/src/main/java/OneQ/OnSurvey/domain/survey/repository/export/SurveyExportRepositoryImpl.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/repository/export/SurveyExportRepositoryImpl.java
@@ -12,6 +12,7 @@ import java.util.List;
 
 import static OneQ.OnSurvey.domain.member.QMember.member;
 import static OneQ.OnSurvey.domain.participation.entity.QQuestionAnswer.questionAnswer;
+import static OneQ.OnSurvey.domain.participation.entity.QResponse.response;
 import static OneQ.OnSurvey.domain.question.entity.QQuestion.question;
 import static OneQ.OnSurvey.domain.survey.entity.QSurvey.survey;
 
@@ -49,7 +50,8 @@ public class SurveyExportRepositoryImpl implements SurveyExportRepository {
                 .from(questionAnswer)
                 .join(question).on(question.questionId.eq(questionAnswer.questionId))
                 .join(member).on(member.id.eq(questionAnswer.memberId))
-                .where(question.surveyId.eq(surveyId))
+                .join(response).on(response.surveyId.eq(surveyId).and(response.memberId.eq(questionAnswer.memberId)))
+                .where(question.surveyId.eq(surveyId).and(response.isResponded.isTrue()))
                 .distinct()
                 .orderBy(member.id.asc())
                 .fetch();
@@ -66,7 +68,8 @@ public class SurveyExportRepositoryImpl implements SurveyExportRepository {
                 ))
                 .from(questionAnswer)
                 .join(question).on(question.questionId.eq(questionAnswer.questionId))
-                .where(question.surveyId.eq(surveyId))
+                .join(response).on(response.surveyId.eq(surveyId).and(response.memberId.eq(questionAnswer.memberId)))
+                .where(question.surveyId.eq(surveyId).and(response.isResponded.isTrue()))
                 .fetch();
     }
 


### PR DESCRIPTION
### ✨ Related Issue
- [OMF-248](https://onsurvey.atlassian.net/browse/OMF-248)
---

### 📌 Task Details
- [x] reponse의 isResponded=true 여부로 완료된 응답에 대해서만 추출

---

### 💬 Review Requirements (Optional)



[OMF-248]: https://onsurvey.atlassian.net/browse/OMF-248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* **Bug Fixes**
  * 설문조사 내보내기 기능에서 응답된 항목만 정확하게 필터링하도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->