### PR TITLE
🐛 (hotfix) OMF-262 설문마감 푸시알림이 단순 응답 제출 시에도 발생하는 버그 수정

### DIFF
--- a/src/main/java/OneQ/OnSurvey/domain/participation/service/response/ResponseCommandService.java
+++ b/src/main/java/OneQ/OnSurvey/domain/participation/service/response/ResponseCommandService.java
@@ -76,6 +76,9 @@ public class ResponseCommandService implements ResponseCommand {
                     if (currCompleted >= dueCount) {
                         survey.updateSurveyStatus(SurveyStatus.CLOSED);
 
+                        long creator = redisAgent.getLongValue(this.creatorKey + surveyId);
+                        eventPublisher.publishEvent(new SurveyCompletedEvent(creator, Map.of()));
+
                         afterCommitExecutor.run(() -> {
                             redisAgent.deleteKeys(List.of(
                                 this.dueCountKey + surveyId,
@@ -91,9 +94,6 @@ public class ResponseCommandService implements ResponseCommand {
                         redisAgent.decrementValue(this.completedKey + surveyId);
                         redisAgent.addToZSet(this.potentialKey + surveyId, String.valueOf(userKey), System.currentTimeMillis());
                     });
-
-                    long creator = redisAgent.getLongValue(this.creatorKey + surveyId);
-                    eventPublisher.publishEvent(new SurveyCompletedEvent(creator, Map.of()));
                 }
 
                 return true;


### PR DESCRIPTION
### ✨ Related Issue
- [설문마감 푸시알림이 단순 응답 제출 시에도 발생하는 버그 수정](https://onsurvey.atlassian.net/browse/OMF-262)

---

### 📌 Task Details
- [x] 설문마감 푸시알림 이벤트 발행 로직이 설문마감 분기 외부에 존재하던 코드 수정
- [x] 설문마감 후에는 `creator`가 0으로 반환되므로 실제 사용자에게 중복된 푸시알림이 전송되지 않음. 단, 불필요하게 남아있는 마감설문의 캐시값을 삭제할 필요가 있으므로 `currCompleted >= dueCount`을 그대로 설문마감 분기 조건으로 유지

---

### 💬 Review Requirements (Optional)

