### PR TITLE
✨ OMF-273 프로모션 코드 기반 결제 금액 분리

### DIFF
--- a/src/main/java/OneQ/OnSurvey/domain/discount/DiscountCodeErrorCode.java
+++ b/src/main/java/OneQ/OnSurvey/domain/discount/DiscountCodeErrorCode.java
@@ -1,0 +1,17 @@
+package OneQ.OnSurvey.domain.discount;
+
+import OneQ.OnSurvey.global.common.exception.ApiErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum DiscountCodeErrorCode implements ApiErrorCode {
+
+    DISCOUNT_CODE_NOT_FOUND("DISCOUNT_404", "유효하지 않은 할인 코드입니다.", HttpStatus.NOT_FOUND);
+
+    private final String errorCode;
+    private final String message;
+    private final HttpStatus status;
+}

--- a/src/main/java/OneQ/OnSurvey/domain/discount/controller/DiscountCodeController.java
+++ b/src/main/java/OneQ/OnSurvey/domain/discount/controller/DiscountCodeController.java
@@ -1,0 +1,43 @@
+package OneQ.OnSurvey.domain.discount.controller;
+
+import OneQ.OnSurvey.global.common.response.SuccessResponse;
+import OneQ.OnSurvey.domain.discount.model.request.CreateDiscountCodeRequest;
+import OneQ.OnSurvey.domain.discount.model.response.DiscountCodeResponse;
+import OneQ.OnSurvey.domain.discount.model.response.ValidateDiscountCodeResponse;
+import OneQ.OnSurvey.domain.discount.service.DiscountCodeCommandService;
+import OneQ.OnSurvey.domain.discount.service.DiscountCodeQueryService;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/v1/discount-codes")
+@RequiredArgsConstructor
+public class DiscountCodeController {
+
+    private final DiscountCodeQueryService discountCodeQueryService;
+    private final DiscountCodeCommandService discountCodeCommandService;
+
+    @GetMapping("/{code}")
+    @Operation(summary = "할인 코드를 검증하고 할인 정보를 반환합니다.")
+    public SuccessResponse<ValidateDiscountCodeResponse> validate(@PathVariable String code) {
+        return SuccessResponse.ok(discountCodeQueryService.validate(code));
+    }
+
+    @PostMapping
+    @Operation(summary = "할인 코드를 생성합니다.")
+    public SuccessResponse<DiscountCodeResponse> create(
+            @RequestBody @Valid CreateDiscountCodeRequest request
+    ) {
+        return SuccessResponse.ok(discountCodeCommandService.create(request));
+    }
+
+    @GetMapping
+    @Operation(summary = "전체 할인 코드 목록을 조회합니다.")
+    public SuccessResponse<List<DiscountCodeResponse>> findAll() {
+        return SuccessResponse.ok(discountCodeQueryService.findAll());
+    }
+}

--- a/src/main/java/OneQ/OnSurvey/domain/discount/entity/DiscountCode.java
+++ b/src/main/java/OneQ/OnSurvey/domain/discount/entity/DiscountCode.java
@@ -1,0 +1,32 @@
+package OneQ.OnSurvey.domain.discount.entity;
+
+import OneQ.OnSurvey.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Entity
+@Table(name = "discount_code")
+public class DiscountCode extends BaseEntity {
+
+    @Id
+    @Column(name = "discount_code_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "organization_name", nullable = false)
+    private String organizationName;
+
+    @Column(name = "code", nullable = false, unique = true, length = 16)
+    private String code;
+
+    public static DiscountCode of(String organizationName, String code) {
+        return DiscountCode.builder()
+                .organizationName(organizationName)
+                .code(code)
+                .build();
+    }
+}

--- a/src/main/java/OneQ/OnSurvey/domain/discount/model/request/CreateDiscountCodeRequest.java
+++ b/src/main/java/OneQ/OnSurvey/domain/discount/model/request/CreateDiscountCodeRequest.java
@@ -1,0 +1,11 @@
+package OneQ.OnSurvey.domain.discount.model.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record CreateDiscountCodeRequest(
+        @NotBlank
+        @Schema(description = "학회(기관) 이름", example = "onsurvey")
+        String organizationName
+) {
+}

--- a/src/main/java/OneQ/OnSurvey/domain/discount/model/response/DiscountCodeResponse.java
+++ b/src/main/java/OneQ/OnSurvey/domain/discount/model/response/DiscountCodeResponse.java
@@ -1,0 +1,21 @@
+package OneQ.OnSurvey.domain.discount.model.response;
+
+import OneQ.OnSurvey.domain.discount.entity.DiscountCode;
+
+import java.time.LocalDateTime;
+
+public record DiscountCodeResponse(
+        Long id,
+        String organizationName,
+        String code,
+        LocalDateTime createdAt
+) {
+    public static DiscountCodeResponse from(DiscountCode entity) {
+        return new DiscountCodeResponse(
+                entity.getId(),
+                entity.getOrganizationName(),
+                entity.getCode(),
+                entity.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/OneQ/OnSurvey/domain/discount/model/response/ValidateDiscountCodeResponse.java
+++ b/src/main/java/OneQ/OnSurvey/domain/discount/model/response/ValidateDiscountCodeResponse.java
@@ -1,0 +1,6 @@
+package OneQ.OnSurvey.domain.discount.model.response;
+
+public record ValidateDiscountCodeResponse(
+        boolean eligible
+) {
+}

--- a/src/main/java/OneQ/OnSurvey/domain/discount/repository/DiscountCodeJpaRepository.java
+++ b/src/main/java/OneQ/OnSurvey/domain/discount/repository/DiscountCodeJpaRepository.java
@@ -1,0 +1,11 @@
+package OneQ.OnSurvey.domain.discount.repository;
+
+import OneQ.OnSurvey.domain.discount.entity.DiscountCode;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface DiscountCodeJpaRepository extends JpaRepository<DiscountCode, Long> {
+    Optional<DiscountCode> findByCode(String code);
+    boolean existsByCode(String code);
+}

--- a/src/main/java/OneQ/OnSurvey/domain/discount/repository/DiscountCodeRepository.java
+++ b/src/main/java/OneQ/OnSurvey/domain/discount/repository/DiscountCodeRepository.java
@@ -1,0 +1,13 @@
+package OneQ.OnSurvey.domain.discount.repository;
+
+import OneQ.OnSurvey.domain.discount.entity.DiscountCode;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface DiscountCodeRepository {
+    DiscountCode save(DiscountCode discountCode);
+    Optional<DiscountCode> findByCode(String code);
+    boolean existsByCode(String code);
+    List<DiscountCode> findAll();
+}

--- a/src/main/java/OneQ/OnSurvey/domain/discount/repository/DiscountCodeRepositoryImpl.java
+++ b/src/main/java/OneQ/OnSurvey/domain/discount/repository/DiscountCodeRepositoryImpl.java
@@ -1,0 +1,35 @@
+package OneQ.OnSurvey.domain.discount.repository;
+
+import OneQ.OnSurvey.domain.discount.entity.DiscountCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class DiscountCodeRepositoryImpl implements DiscountCodeRepository {
+
+    private final DiscountCodeJpaRepository jpaRepository;
+
+    @Override
+    public DiscountCode save(DiscountCode discountCode) {
+        return jpaRepository.save(discountCode);
+    }
+
+    @Override
+    public Optional<DiscountCode> findByCode(String code) {
+        return jpaRepository.findByCode(code);
+    }
+
+    @Override
+    public boolean existsByCode(String code) {
+        return jpaRepository.existsByCode(code);
+    }
+
+    @Override
+    public List<DiscountCode> findAll() {
+        return jpaRepository.findAll();
+    }
+}

--- a/src/main/java/OneQ/OnSurvey/domain/discount/service/DiscountCodeCommandService.java
+++ b/src/main/java/OneQ/OnSurvey/domain/discount/service/DiscountCodeCommandService.java
@@ -1,0 +1,31 @@
+package OneQ.OnSurvey.domain.discount.service;
+
+import OneQ.OnSurvey.domain.discount.entity.DiscountCode;
+import OneQ.OnSurvey.domain.discount.model.request.CreateDiscountCodeRequest;
+import OneQ.OnSurvey.domain.discount.model.response.DiscountCodeResponse;
+import OneQ.OnSurvey.domain.discount.repository.DiscountCodeRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class DiscountCodeCommandService {
+
+    private final DiscountCodeRepository discountCodeRepository;
+
+    public DiscountCodeResponse create(CreateDiscountCodeRequest request) {
+        String code = UUID.randomUUID().toString().replace("-", "").substring(0, 16).toUpperCase();
+        DiscountCode discountCode = DiscountCode.of(request.organizationName(), code);
+        discountCode = discountCodeRepository.save(discountCode);
+
+        log.info("[DiscountCode:create] 할인 코드 생성 - org={}, code={}", request.organizationName(), code);
+
+        return DiscountCodeResponse.from(discountCode);
+    }
+}

--- a/src/main/java/OneQ/OnSurvey/domain/discount/service/DiscountCodeQueryService.java
+++ b/src/main/java/OneQ/OnSurvey/domain/discount/service/DiscountCodeQueryService.java
@@ -1,0 +1,42 @@
+package OneQ.OnSurvey.domain.discount.service;
+
+import OneQ.OnSurvey.global.common.exception.CustomException;
+import OneQ.OnSurvey.domain.discount.DiscountCodeErrorCode;
+import OneQ.OnSurvey.domain.discount.entity.DiscountCode;
+import OneQ.OnSurvey.domain.discount.model.response.DiscountCodeResponse;
+import OneQ.OnSurvey.domain.discount.model.response.ValidateDiscountCodeResponse;
+import OneQ.OnSurvey.domain.discount.repository.DiscountCodeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DiscountCodeQueryService {
+
+    private final DiscountCodeRepository discountCodeRepository;
+
+    /** 코드 존재 여부만 확인 */
+    public ValidateDiscountCodeResponse validate(String code) {
+        boolean eligible = discountCodeRepository.existsByCode(code);
+        if (!eligible) {
+            throw new CustomException(DiscountCodeErrorCode.DISCOUNT_CODE_NOT_FOUND);
+        }
+        return new ValidateDiscountCodeResponse(true);
+    }
+
+    /** 설문 등록 시 코드 검증 후 엔티티 반환 */
+    public DiscountCode getByCode(String code) {
+        return discountCodeRepository.findByCode(code)
+                .orElseThrow(() -> new CustomException(DiscountCodeErrorCode.DISCOUNT_CODE_NOT_FOUND));
+    }
+
+    public List<DiscountCodeResponse> findAll() {
+        return discountCodeRepository.findAll().stream()
+                .map(DiscountCodeResponse::from)
+                .toList();
+    }
+}

--- a/src/main/java/OneQ/OnSurvey/domain/survey/entity/SurveyInfo.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/entity/SurveyInfo.java
@@ -51,6 +51,9 @@ public class SurveyInfo {
 
     private Integer promotionAmount;
 
+    @Column(name = "discount_code_id")
+    private Long discountCodeId;
+
     @Builder.Default
     @Column(nullable = false)
     private boolean refundable = true;
@@ -65,7 +68,8 @@ public class SurveyInfo {
             Integer agePrice,
             Integer residencePrice,
             Integer dueCountPrice,
-            Integer promotionAmount
+            Integer promotionAmount,
+            Long discountCodeId
     ) {
         return SurveyInfo.builder()
                 .surveyId(surveyId)
@@ -79,6 +83,7 @@ public class SurveyInfo {
                 .residencePrice(residencePrice)
                 .dueCountPrice(dueCountPrice)
                 .promotionAmount(promotionAmount)
+                .discountCodeId(discountCodeId)
                 .refundable(true)
                 .build();
     }
@@ -92,7 +97,8 @@ public class SurveyInfo {
             Integer agePrice,
             Integer residencePrice,
             Integer dueCountPrice,
-            Integer promotionAmount
+            Integer promotionAmount,
+            Long discountCodeId
     ) {
         this.dueCount = dueCount;
         this.gender = gender;
@@ -103,6 +109,7 @@ public class SurveyInfo {
         this.residencePrice = residencePrice;
         this.dueCountPrice = dueCountPrice;
         this.promotionAmount = promotionAmount;
+        this.discountCodeId = discountCodeId;
     }
 
     public void markNonRefundable() {

--- a/src/main/java/OneQ/OnSurvey/domain/survey/model/request/SurveyFormRequest.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/model/request/SurveyFormRequest.java
@@ -35,6 +35,9 @@ public record SurveyFormRequest(
         Integer dueCountPrice,
 
         @Schema(description = "총 코인", example = "10000")
-        Integer totalCoin
+        Integer totalCoin,
+
+        @Schema(description = "할인 코드 (선택)", example = "A1B2C3D4E5F6G7H8")
+        String discountCode
 ) {
 }

--- a/src/main/java/OneQ/OnSurvey/domain/survey/service/command/SurveyCommandService.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/service/command/SurveyCommandService.java
@@ -5,6 +5,8 @@ import OneQ.OnSurvey.domain.member.MemberErrorCode;
 import OneQ.OnSurvey.domain.member.repository.MemberRepository;
 import OneQ.OnSurvey.domain.member.value.Interest;
 import OneQ.OnSurvey.domain.question.service.QuestionQueryService;
+import OneQ.OnSurvey.domain.discount.entity.DiscountCode;
+import OneQ.OnSurvey.domain.discount.service.DiscountCodeQueryService;
 import OneQ.OnSurvey.global.promotion.application.PromotionTierResolver;
 import OneQ.OnSurvey.domain.survey.SurveyErrorCode;
 import OneQ.OnSurvey.domain.survey.entity.Screening;
@@ -63,6 +65,7 @@ public class SurveyCommandService implements SurveyCommand {
     private final RedisAgent redisAgent;
     private final QuestionQueryService questionQueryService;
     private final PromotionTierResolver promotionTierResolver;
+    private final DiscountCodeQueryService discountCodeQueryService;
 
     private final AlertNotifier alertNotifier;
     private final AfterCommitExecutor afterCommitExecutor;
@@ -125,6 +128,14 @@ public class SurveyCommandService implements SurveyCommand {
 
         Set<AgeRange> ages = (request.ages() == null) ? Set.of() : new HashSet<>(request.ages());
 
+        // 할인 코드 저장 (존재 여부만 확인 후 ID 기록)
+        Long discountCodeId = null;
+        if (request.discountCode() != null && !request.discountCode().isBlank()) {
+            DiscountCode discountCode = discountCodeQueryService.getByCode(request.discountCode());
+            discountCodeId = discountCode.getId();
+            log.info("[SurveySubmit] 할인 코드 저장 - surveyId={}, org={}", surveyId, discountCode.getOrganizationName());
+        }
+
         survey.updateSurvey(survey.getTitle(), survey.getDescription(), request.deadline(), request.totalCoin());
 
         int questionCount = questionQueryService.countQuestionsBySurveyId(surveyId);
@@ -141,6 +152,7 @@ public class SurveyCommandService implements SurveyCommand {
                 request.residencePrice(),
                 request.dueCountPrice(),
                 resolvedPromotionAmount,
+                discountCodeId,
                 true
         );
 
@@ -166,6 +178,7 @@ public class SurveyCommandService implements SurveyCommand {
                 Residence.ALL,
                 0, 0, 0, 0,
                 0,
+                null,
                 false
         );
 
@@ -300,15 +313,16 @@ public class SurveyCommandService implements SurveyCommand {
             Integer residencePrice,
             Integer dueCountPrice,
             Integer promotionAmount,
+            Long discountCodeId,
             boolean refundable
     ) {
         SurveyInfo info = surveyInfoRepository.findBySurveyId(surveyId)
                 .orElseGet(() -> SurveyInfo.createSurveyInfo(
                         surveyId, dueCount, gender, ages, residence,
-                        genderPrice, agePrice, residencePrice, dueCountPrice, promotionAmount
+                        genderPrice, agePrice, residencePrice, dueCountPrice, promotionAmount, discountCodeId
                 ));
 
-        info.updateSurveyInfo(dueCount, gender, ages, residence, genderPrice, agePrice, residencePrice, dueCountPrice, promotionAmount);
+        info.updateSurveyInfo(dueCount, gender, ages, residence, genderPrice, agePrice, residencePrice, dueCountPrice, promotionAmount, discountCodeId);
 
         if (!refundable) info.markNonRefundable();
 


### PR DESCRIPTION
### ✨ Related Issue
- [OMF-273](https://onsurvey.atlassian.net/browse/OMF-273)
---

### 📌 Task Details
- [x] 할인 코드 관리 엔티티 추가 (discount_code)
- [x] 설문 생성시 discountCode를 받아서 코드별 설문 카운팅 가능

---

### 💬 Review Requirements (Optional)
- 할인 코드를 생성해야 하는데, 자동화는 불가능 한 상황이라(학회명은 유저 정보에서 알 수 없는 외부 데이터이기 때문에) 별로 API로 분리한 상황입니다.
- 백오피스에 연동해도 되고 그냥 스웨거에서 호출해봐도 될듯 합니다 (현재로서는 bo에 붙일 필요까지는 없다고 판단..)


[OMF-273]: https://onsurvey.atlassian.net/browse/OMF-273?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 할인 코드 검증, 생성, 조회 기능 추가
  * 설문조사 제출 시 할인 코드 적용 가능

<!-- end of auto-generated comment: release notes by coderabbit.ai -->