### PR TITLE
✨ OMF-274 구글폼 변환성공 문항 개수 반환

### DIFF
--- a/src/main/java/OneQ/OnSurvey/domain/discount/DiscountCodeErrorCode.java
+++ b/src/main/java/OneQ/OnSurvey/domain/discount/DiscountCodeErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum DiscountCodeErrorCode implements ApiErrorCode {
 
-    DISCOUNT_CODE_NOT_FOUND("DISCOUNT_404", "유효하지 않은 할인 코드입니다.", HttpStatus.NOT_FOUND);
+    DISCOUNT_CODE_NOT_FOUND("DISCOUNT_404", "유효하지 않은 할인 코드입니다.", HttpStatus.NOT_FOUND),
+    DISCOUNT_CODE_EXPIRED("DISCOUNT_410", "만료된 할인 코드입니다.", HttpStatus.GONE);
 
     private final String errorCode;
     private final String message;

--- a/src/main/java/OneQ/OnSurvey/domain/discount/entity/DiscountCode.java
+++ b/src/main/java/OneQ/OnSurvey/domain/discount/entity/DiscountCode.java
@@ -4,6 +4,8 @@ import OneQ.OnSurvey.global.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDate;
+
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -20,13 +22,17 @@ public class DiscountCode extends BaseEntity {
     @Column(name = "organization_name", nullable = false)
     private String organizationName;
 
-    @Column(name = "code", nullable = false, unique = true, length = 16)
+    @Column(name = "code", nullable = false, unique = true, length = 6)
     private String code;
 
-    public static DiscountCode of(String organizationName, String code) {
+    @Column(name = "expired_at", nullable = false)
+    private LocalDate expiredAt;
+
+    public static DiscountCode of(String organizationName, String code, LocalDate expiredAt) {
         return DiscountCode.builder()
                 .organizationName(organizationName)
                 .code(code)
+                .expiredAt(expiredAt)
                 .build();
     }
 }

--- a/src/main/java/OneQ/OnSurvey/domain/discount/model/request/CreateDiscountCodeRequest.java
+++ b/src/main/java/OneQ/OnSurvey/domain/discount/model/request/CreateDiscountCodeRequest.java
@@ -1,6 +1,7 @@
 package OneQ.OnSurvey.domain.discount.model.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.FutureOrPresent;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
@@ -10,7 +11,9 @@ public record CreateDiscountCodeRequest(
         @NotBlank
         @Schema(description = "학회(기관) 이름", example = "onsurvey")
         String organizationName,
+
         @NotNull
+        @FutureOrPresent
         @Schema(description = "코드 만료 기한", example = "2026-12-31")
         LocalDate expiredAt
 ) {

--- a/src/main/java/OneQ/OnSurvey/domain/discount/model/request/CreateDiscountCodeRequest.java
+++ b/src/main/java/OneQ/OnSurvey/domain/discount/model/request/CreateDiscountCodeRequest.java
@@ -2,10 +2,16 @@ package OneQ.OnSurvey.domain.discount.model.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
 
 public record CreateDiscountCodeRequest(
         @NotBlank
         @Schema(description = "학회(기관) 이름", example = "onsurvey")
-        String organizationName
+        String organizationName,
+        @NotNull
+        @Schema(description = "코드 만료 기한", example = "2026-12-31")
+        LocalDate expiredAt
 ) {
 }

--- a/src/main/java/OneQ/OnSurvey/domain/discount/model/response/DiscountCodeResponse.java
+++ b/src/main/java/OneQ/OnSurvey/domain/discount/model/response/DiscountCodeResponse.java
@@ -2,12 +2,14 @@ package OneQ.OnSurvey.domain.discount.model.response;
 
 import OneQ.OnSurvey.domain.discount.entity.DiscountCode;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 public record DiscountCodeResponse(
         Long id,
         String organizationName,
         String code,
+        LocalDate expiredAt,
         LocalDateTime createdAt
 ) {
     public static DiscountCodeResponse from(DiscountCode entity) {
@@ -15,6 +17,7 @@ public record DiscountCodeResponse(
                 entity.getId(),
                 entity.getOrganizationName(),
                 entity.getCode(),
+                entity.getExpiredAt(),
                 entity.getCreatedAt()
         );
     }

--- a/src/main/java/OneQ/OnSurvey/domain/discount/service/DiscountCodeCommandService.java
+++ b/src/main/java/OneQ/OnSurvey/domain/discount/service/DiscountCodeCommandService.java
@@ -9,7 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.UUID;
+import java.security.SecureRandom;
 
 @Slf4j
 @Service
@@ -17,15 +17,31 @@ import java.util.UUID;
 @Transactional
 public class DiscountCodeCommandService {
 
+    private static final String CHARACTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+    private static final int CODE_LENGTH = 6;
+    private static final SecureRandom RANDOM = new SecureRandom();
+
     private final DiscountCodeRepository discountCodeRepository;
 
     public DiscountCodeResponse create(CreateDiscountCodeRequest request) {
-        String code = UUID.randomUUID().toString().replace("-", "").substring(0, 16).toUpperCase();
-        DiscountCode discountCode = DiscountCode.of(request.organizationName(), code);
+        String code = generateUniqueCode();
+        DiscountCode discountCode = DiscountCode.of(request.organizationName(), code, request.expiredAt());
         discountCode = discountCodeRepository.save(discountCode);
 
-        log.info("[DiscountCode:create] 할인 코드 생성 - org={}, code={}", request.organizationName(), code);
+        log.info("[DiscountCode:create] 할인 코드 생성 - org={}, code={}, expiredAt={}", request.organizationName(), code, request.expiredAt());
 
         return DiscountCodeResponse.from(discountCode);
+    }
+
+    private String generateUniqueCode() {
+        String code;
+        do {
+            StringBuilder sb = new StringBuilder(CODE_LENGTH);
+            for (int i = 0; i < CODE_LENGTH; i++) {
+                sb.append(CHARACTERS.charAt(RANDOM.nextInt(CHARACTERS.length())));
+            }
+            code = sb.toString();
+        } while (discountCodeRepository.existsByCode(code));
+        return code;
     }
 }

--- a/src/main/java/OneQ/OnSurvey/domain/discount/service/DiscountCodeQueryService.java
+++ b/src/main/java/OneQ/OnSurvey/domain/discount/service/DiscountCodeQueryService.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Service
@@ -21,22 +22,29 @@ public class DiscountCodeQueryService {
 
     /** 코드 존재 여부만 확인 */
     public ValidateDiscountCodeResponse validate(String code) {
-        boolean eligible = discountCodeRepository.existsByCode(code);
-        if (!eligible) {
-            throw new CustomException(DiscountCodeErrorCode.DISCOUNT_CODE_NOT_FOUND);
-        }
+        DiscountCode discountCode = discountCodeRepository.findByCode(code)
+                .orElseThrow(() -> new CustomException(DiscountCodeErrorCode.DISCOUNT_CODE_NOT_FOUND));
+        validateNotExpired(discountCode);
         return new ValidateDiscountCodeResponse(true);
     }
 
     /** 설문 등록 시 코드 검증 후 엔티티 반환 */
     public DiscountCode getByCode(String code) {
-        return discountCodeRepository.findByCode(code)
+        DiscountCode discountCode = discountCodeRepository.findByCode(code)
                 .orElseThrow(() -> new CustomException(DiscountCodeErrorCode.DISCOUNT_CODE_NOT_FOUND));
+        validateNotExpired(discountCode);
+        return discountCode;
     }
 
     public List<DiscountCodeResponse> findAll() {
         return discountCodeRepository.findAll().stream()
                 .map(DiscountCodeResponse::from)
                 .toList();
+    }
+
+    private void validateNotExpired(DiscountCode discountCode) {
+        if (discountCode.getExpiredAt().isBefore(LocalDate.now())) {
+            throw new CustomException(DiscountCodeErrorCode.DISCOUNT_CODE_EXPIRED);
+        }
     }
 }

--- a/src/main/java/OneQ/OnSurvey/domain/question/entity/question/Title.java
+++ b/src/main/java/OneQ/OnSurvey/domain/question/entity/question/Title.java
@@ -9,22 +9,22 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
-@Getter @SuperBuilder
+@Getter
+@SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-@DiscriminatorValue(value = QuestionType.Values.IMAGE)
-public class Image extends Question {
+@DiscriminatorValue(value = QuestionType.Values.TITLE)
+public class Title extends Question {
 
-    public static Image of(
+    public static Title of(
         Long surveyId,
         Integer order,
         String title,
         String description,
         Integer section,
-        QuestionType type,
-        String imageUrl
+        QuestionType type
     ) {
-        return Image.builder()
+        return Title.builder()
             .surveyId(surveyId)
             .order(order)
             .title(title)
@@ -32,7 +32,7 @@ public class Image extends Question {
             .isRequired(false)
             .type(type.name())
             .section(section)
-            .imageUrl(imageUrl)
+            .imageUrl(null)
             .build();
     }
 
@@ -40,9 +40,8 @@ public class Image extends Question {
         String title,
         String description,
         Integer order,
-        Integer section,
-        String imageUrl
+        Integer section
     ) {
-        super.updateQuestion(title, description, false, order, section, imageUrl);
+        super.updateQuestion(title, description, false, order, section, null);
     }
 }

--- a/src/main/java/OneQ/OnSurvey/domain/question/model/QuestionType.java
+++ b/src/main/java/OneQ/OnSurvey/domain/question/model/QuestionType.java
@@ -14,6 +14,7 @@ public enum QuestionType {
     NUMBER("숫자형", Values.NUMBER),
     DATE("날짜형", Values.DATE),
     IMAGE("이미지형", Values.IMAGE),
+    TITLE("제목형", Values.TITLE),
     TEXT("주관식", Values.TEXT);
     private final String description;
     private final String value;
@@ -28,6 +29,7 @@ public enum QuestionType {
         public static final String DATE = "DATE";
         public static final String TEXT = "TEXT";
         public static final String IMAGE = "IMAGE";
+        public static final String TITLE = "TITLE";
     }
 
     public boolean isText() {

--- a/src/main/java/OneQ/OnSurvey/domain/question/service/QuestionCommandService.java
+++ b/src/main/java/OneQ/OnSurvey/domain/question/service/QuestionCommandService.java
@@ -200,10 +200,16 @@ public class QuestionCommandService implements QuestionCommand {
             image.updateQuestion(
                 upsertInfo.getTitle(),
                 upsertInfo.getDescription(),
-                upsertInfo.getIsRequired(),
                 upsertInfo.getQuestionOrder(),
                 upsertInfo.getSection(),
                 upsertInfo.getImageUrl()
+            );
+        } else if (question instanceof Title title) {
+            title.updateQuestion(
+                upsertInfo.getTitle(),
+                upsertInfo.getDescription(),
+                upsertInfo.getQuestionOrder(),
+                upsertInfo.getSection()
             );
         }
     }
@@ -302,10 +308,18 @@ public class QuestionCommandService implements QuestionCommand {
                 upsertInfo.getQuestionOrder(),
                 upsertInfo.getTitle(),
                 upsertInfo.getDescription(),
-                upsertInfo.getIsRequired(),
                 upsertInfo.getSection(),
                 type,
                 upsertInfo.getImageUrl()
+            );
+        }  else if (QuestionType.TITLE.equals(type)) {
+            return Title.of(
+                surveyId,
+                upsertInfo.getQuestionOrder(),
+                upsertInfo.getTitle(),
+                upsertInfo.getDescription(),
+                upsertInfo.getSection(),
+                type
             );
         } else {
             throw new CustomException(ErrorCode.INVALID_REQUEST);

--- a/src/main/java/OneQ/OnSurvey/domain/question/service/QuestionCommandService.java
+++ b/src/main/java/OneQ/OnSurvey/domain/question/service/QuestionCommandService.java
@@ -312,7 +312,7 @@ public class QuestionCommandService implements QuestionCommand {
                 type,
                 upsertInfo.getImageUrl()
             );
-        }  else if (QuestionType.TITLE.equals(type)) {
+        } else if (QuestionType.TITLE.equals(type)) {
             return Title.of(
                 surveyId,
                 upsertInfo.getQuestionOrder(),

--- a/src/main/java/OneQ/OnSurvey/domain/question/service/QuestionCommandService.java
+++ b/src/main/java/OneQ/OnSurvey/domain/question/service/QuestionCommandService.java
@@ -36,7 +36,7 @@ public class QuestionCommandService implements QuestionCommand {
 
     @Override
     public QuestionUpsertDto upsertQuestionList(QuestionUpsertDto upsertDto) {
-        log.info("[QUESTION:COMMAND:upsertQuestionList] 문항 UPSERT - surveyId: {}, upsertInfoList: {}", upsertDto.getSurveyId(), upsertDto.getUpsertInfoList().toString());
+        log.info("[QUESTION:COMMAND:upsertQuestionList] 문항 UPSERT - surveyId: {}", upsertDto.getSurveyId());
 
         Long surveyId = upsertDto.getSurveyId();
         List<QuestionUpsertDto.UpsertInfo> upsertInfoList = upsertDto.getUpsertInfoList();
@@ -314,7 +314,7 @@ public class QuestionCommandService implements QuestionCommand {
 
     @Override
     public List<OptionUpsertDto> upsertChoiceOptionList(List<OptionUpsertDto> upsertDtoList) {
-        log.info("[QUESTION:COMMAND:upsertChoiceOptionList] 보기 UPSERT - upsertDtoList : {}", upsertDtoList.toString());
+        log.info("[QUESTION:COMMAND:upsertChoiceOptionList] 보기 UPSERT");
 
         List<ChoiceOption> finalList = new ArrayList<>();
 
@@ -345,11 +345,10 @@ public class QuestionCommandService implements QuestionCommand {
                 .map(ChoiceOption::getChoiceOptionId)
                 .filter(optionId -> !updateIdSet.contains(optionId))
                 .collect(Collectors.toSet());
-            log.info("[QUESTION:COMMAND:upsertChoiceOptionList] 삭제되는 문항: {}, 보기 IDs: {}", questionId, deleteIdSet);
-
-            choiceOptionRepository.deleteAll(deleteIdSet);
-
-            log.info("[QUESTION:COMMAND:upsertChoiceOptionList] DELETE 진행");
+            if (!deleteIdSet.isEmpty()) {
+                log.info("[QUESTION:COMMAND:upsertChoiceOptionList] 삭제되는 문항: {}, 보기 IDs: {}", questionId, deleteIdSet);
+                choiceOptionRepository.deleteAll(deleteIdSet);
+            }
 
             // 5. Update 대상 수정
             Map<Long, OptionDto> updateInfoMap = updateInfoList.stream().collect(Collectors.toMap(

--- a/src/main/java/OneQ/OnSurvey/domain/survey/SurveyErrorCode.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/SurveyErrorCode.java
@@ -31,7 +31,9 @@ public enum SurveyErrorCode implements ApiErrorCode {
     SURVEY_FREE_PROMOTION_NOT_ALLOWED("SURVEY_PROMOTION_400", "무료 설문은 프로모션 지급 대상이 아닙니다.", HttpStatus.BAD_REQUEST),
 
     FORM_REQUEST_NOT_FOUND("FORM_REQUEST_404", "구글 폼 신청을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-    FORM_CONVERSION_FAILED("FORM_REQUEST_001", "구글 폼 변환에 실패했습니다.", HttpStatus.BAD_REQUEST);
+    FORM_CONVERSION_FAILED("FORM_REQUEST_001", "구글 폼 변환에 실패했습니다.", HttpStatus.BAD_REQUEST),
+    FORM_VALIDATION_FAILED("FORM_REQUEST_002", "구글 폼 링크 유효성 검사에 실패했습니다.", HttpStatus.BAD_REQUEST),
+    FORM_INVALID("FORM_REQUEST_003", "구글 폼 링크가 유효하지 않습니다.", HttpStatus.BAD_REQUEST);
 
     private final String errorCode;
     private final String message;

--- a/src/main/java/OneQ/OnSurvey/domain/survey/SurveyErrorCode.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/SurveyErrorCode.java
@@ -31,7 +31,9 @@ public enum SurveyErrorCode implements ApiErrorCode {
     SURVEY_FREE_PROMOTION_NOT_ALLOWED("SURVEY_PROMOTION_400", "무료 설문은 프로모션 지급 대상이 아닙니다.", HttpStatus.BAD_REQUEST),
 
     FORM_REQUEST_NOT_FOUND("FORM_REQUEST_404", "구글 폼 신청을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-    FORM_CONVERSION_FAILED("FORM_REQUEST_001", "구글 폼 변환에 실패했습니다.", HttpStatus.BAD_REQUEST);
+    FORM_CONVERSION_FAILED("FORM_REQUEST_001", "구글 폼 변환에 실패했습니다.", HttpStatus.BAD_REQUEST),
+    FORM_REQUEST_NOT_YET_REGISTERED("FORM_REQUEST_409", "아직 설문 변환이 완료되지 않았습니다.", HttpStatus.CONFLICT),
+    FORM_REQUEST_MEMBER_NOT_FOUND("FORM_REQUEST_MEMBER_404", "폼 신청자에 해당하는 회원을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
 
     private final String errorCode;
     private final String message;

--- a/src/main/java/OneQ/OnSurvey/domain/survey/controller/FormRequestController.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/controller/FormRequestController.java
@@ -1,15 +1,19 @@
 package OneQ.OnSurvey.domain.survey.controller;
 
 import OneQ.OnSurvey.domain.survey.model.formRequest.FormListResponse;
+import OneQ.OnSurvey.domain.survey.model.formRequest.FormPublishRequest;
 import OneQ.OnSurvey.domain.survey.model.formRequest.FormRequestDto;
 import OneQ.OnSurvey.domain.survey.model.formRequest.FormRequestResponse;
+import OneQ.OnSurvey.domain.survey.model.response.SurveyFormResponse;
 import OneQ.OnSurvey.domain.survey.service.formRequest.FormCreator;
 import OneQ.OnSurvey.domain.survey.service.formRequest.FormFinder;
+import OneQ.OnSurvey.domain.survey.service.formRequest.FormPublisher;
 import OneQ.OnSurvey.domain.survey.service.formRequest.FormUpdater;
 import OneQ.OnSurvey.global.common.response.PageResponse;
 import OneQ.OnSurvey.global.common.response.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
@@ -25,6 +29,7 @@ public class FormRequestController {
     private final FormCreator formCreator;
     private final FormFinder formFinder;
     private final FormUpdater formUpdater;
+    private final FormPublisher formPublisher;
 
     @PostMapping
     @Operation(summary = "폼 등록 신청", description = "폼을 등록하기 위한 신청을 생성합니다.")
@@ -64,7 +69,16 @@ public class FormRequestController {
             @PathVariable Long requestId,
             @RequestParam Long surveyId
     ) {
-        formUpdater.markAsRegistered(requestId, surveyId);
+        formUpdater.markAsRegistered(requestId, surveyId, null);
         return SuccessResponse.ok("폼이 온서베이에 등록되었습니다.");
+    }
+
+    @PatchMapping("/{requestId}/publish")
+    @Operation(summary = "폼 설문 발행", description = "변환 완료된 설문에 스크리닝 및 세그먼트 정보를 적용하고 발행합니다.")
+    public SuccessResponse<SurveyFormResponse> publishFormRequest(
+            @PathVariable Long requestId,
+            @RequestBody @Valid FormPublishRequest request
+    ) {
+        return SuccessResponse.ok(formPublisher.publishFormRequest(requestId, request));
     }
 }

--- a/src/main/java/OneQ/OnSurvey/domain/survey/controller/FormRequestController.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/controller/FormRequestController.java
@@ -1,6 +1,8 @@
 package OneQ.OnSurvey.domain.survey.controller;
 
+import OneQ.OnSurvey.domain.survey.model.formRequest.FormValidationResponse;
 import OneQ.OnSurvey.domain.survey.model.formRequest.FormListResponse;
+import OneQ.OnSurvey.domain.survey.model.formRequest.FormValidationRequestDto;
 import OneQ.OnSurvey.domain.survey.model.formRequest.FormRequestDto;
 import OneQ.OnSurvey.domain.survey.model.formRequest.FormRequestResponse;
 import OneQ.OnSurvey.domain.survey.service.formRequest.FormCreator;
@@ -66,5 +68,16 @@ public class FormRequestController {
     ) {
         formUpdater.markAsRegistered(requestId, surveyId);
         return SuccessResponse.ok("폼이 온서베이에 등록되었습니다.");
+    }
+
+    @PostMapping("/validation")
+    @Operation(summary = "폼 링크 유효성 검사", description = "구글 폼 편집 URL로부터 전체 문항 수 중 변환 가능한 문항 수를 리턴합니다. 변환 불가능한 문항 존재 시 관련 정보를 추가로 반환합니다.")
+    public SuccessResponse<FormValidationResponse> getConvertableCounts(
+        @RequestBody FormValidationRequestDto request
+    ) {
+        log.info("[FormRequest] 폼 링크 유효성 검사 - URL: {}, requester: {}", request.formLink(), request.requesterEmail());
+
+        FormValidationResponse response = formCreator.validationFormRequestLink(request);
+        return SuccessResponse.ok(response);
     }
 }

--- a/src/main/java/OneQ/OnSurvey/domain/survey/controller/FormRequestController.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/controller/FormRequestController.java
@@ -11,6 +11,7 @@ import OneQ.OnSurvey.domain.survey.service.formRequest.FormCreator;
 import OneQ.OnSurvey.domain.survey.service.formRequest.FormFinder;
 import OneQ.OnSurvey.domain.survey.service.formRequest.FormPublisher;
 import OneQ.OnSurvey.domain.survey.service.formRequest.FormUpdater;
+import OneQ.OnSurvey.global.auth.custom.Authenticatable;
 import OneQ.OnSurvey.global.common.response.PageResponse;
 import OneQ.OnSurvey.global.common.response.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -20,6 +21,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j
@@ -34,11 +36,12 @@ public class FormRequestController {
     private final FormPublisher formPublisher;
 
     @PostMapping
-    @Operation(summary = "폼 등록 신청", description = "폼을 등록하기 위한 신청을 생성합니다.")
+    @Operation(summary = "폼 등록 신청 및 설문 발행", description = "폼을 등록하기 위한 신청을 생성한 뒤 설문변환 및 발행을 진행합니다.")
     public SuccessResponse<Long> createGoogleFormRequest(
-            @RequestBody FormRequestDto request
+        @AuthenticationPrincipal Authenticatable principal,
+        @RequestBody @Valid FormRequestDto request
     ) {
-        return SuccessResponse.ok(formCreator.createFormRequest(request));
+        return SuccessResponse.ok(formCreator.createFormRequest(principal.getUserKey(), principal.getMemberId(), request));
     }
 
     @GetMapping
@@ -78,7 +81,7 @@ public class FormRequestController {
     @PostMapping("/validation")
     @Operation(summary = "폼 링크 유효성 검사", description = "구글 폼 편집 URL로부터 전체 문항 수 중 변환 가능한 문항 수를 리턴합니다. 변환 불가능한 문항 존재 시 관련 정보를 추가로 반환합니다.")
     public SuccessResponse<FormValidationResponse> getConvertableCounts(
-        @RequestBody FormValidationRequestDto request
+        @RequestBody @Valid FormValidationRequestDto request
     ) {
         log.info("[FormRequest] 폼 링크 유효성 검사 - URL: {}, requester: {}", request.formLink(), request.requesterEmail());
 

--- a/src/main/java/OneQ/OnSurvey/domain/survey/controller/FormRequestController.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/controller/FormRequestController.java
@@ -83,7 +83,7 @@ public class FormRequestController {
     public SuccessResponse<FormValidationResponse> getConvertableCounts(
         @RequestBody @Valid FormValidationRequestDto request
     ) {
-        log.info("[FormRequest] 폼 링크 유효성 검사 - URL: {}, requester: {}", request.formLink(), request.requesterEmail());
+        log.info("[FormRequest] 폼 링크 유효성 검사 - URL: {}", request.formLink());
 
         FormValidationResponse response = formCreator.validationFormRequestLink(request);
         return SuccessResponse.ok(response);

--- a/src/main/java/OneQ/OnSurvey/domain/survey/entity/FormRequest.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/entity/FormRequest.java
@@ -20,6 +20,9 @@ public class FormRequest extends BaseEntity {
     @Column(columnDefinition = "TEXT", nullable = false)
     private String formLink;
 
+    @Column(name = "user_key", nullable = false)
+    private Long userKey;
+
     @Column(nullable = false, length = 100)
     private String requesterEmail;
 
@@ -40,12 +43,13 @@ public class FormRequest extends BaseEntity {
     @Column(name = "registered_survey_id")
     private Long registeredSurveyId;
 
-    public static FormRequest createRequest(String formLink, String requesterEmail) {
+    public static FormRequest createRequest(String formLink, String requesterEmail, Long userKey) {
         return FormRequest.builder()
-                .formLink(formLink)
-                .requesterEmail(requesterEmail)
-                .isRegistered(false)
-                .build();
+            .formLink(formLink)
+            .userKey(userKey)
+            .requesterEmail(requesterEmail)
+            .isRegistered(false)
+            .build();
     }
 
     public void markAsRegistered(Long surveyId, Integer questionCount) {

--- a/src/main/java/OneQ/OnSurvey/domain/survey/entity/FormRequest.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/entity/FormRequest.java
@@ -5,8 +5,6 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
 
-import java.time.LocalDate;
-
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -22,19 +20,16 @@ public class FormRequest extends BaseEntity {
     @Column(columnDefinition = "TEXT", nullable = false)
     private String formLink;
 
-    @Column(nullable = false)
-    private Integer questionCount;
-
-    @Column(nullable = false)
-    private Integer targetResponseCount;
-
-    @Column(nullable = false)
-    private LocalDate deadline;
-
     @Column(nullable = false, length = 100)
     private String requesterEmail;
 
-    @Column(nullable = false)
+    @Column
+    private Integer questionCount;
+
+    @Column
+    private Integer targetResponseCount;
+
+    @Column
     private Integer price;
 
     @Column(name = "is_registered", nullable = false)
@@ -45,27 +40,17 @@ public class FormRequest extends BaseEntity {
     @Column(name = "registered_survey_id")
     private Long registeredSurveyId;
 
-    public static FormRequest createRequest(
-            String formLink,
-            Integer questionCount,
-            Integer targetResponseCount,
-            LocalDate deadline,
-            String requesterEmail,
-            Integer price
-    ) {
+    public static FormRequest createRequest(String formLink, String requesterEmail) {
         return FormRequest.builder()
                 .formLink(formLink)
-                .questionCount(questionCount)
-                .targetResponseCount(targetResponseCount)
-                .deadline(deadline)
                 .requesterEmail(requesterEmail)
-                .price(price)
                 .isRegistered(false)
                 .build();
     }
 
-    public void markAsRegistered(Long surveyId) {
+    public void markAsRegistered(Long surveyId, Integer questionCount) {
         this.isRegistered = true;
         this.registeredSurveyId = surveyId;
+        this.questionCount = questionCount;
     }
 }

--- a/src/main/java/OneQ/OnSurvey/domain/survey/entity/Survey.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/entity/Survey.java
@@ -93,7 +93,8 @@ public class Survey extends BaseEntity {
     }
 
     public void updateInterests(Set<Interest> interests) {
-        this.interests = interests;
+        this.interests.clear();
+        this.interests.addAll(interests);
     }
 
     public void markFree() {

--- a/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/FormConversionPayload.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/FormConversionPayload.java
@@ -3,6 +3,7 @@ package OneQ.OnSurvey.domain.survey.model.formRequest;
 import java.util.List;
 
 public record FormConversionPayload (
+    Long requestId,
     List<String> urls
 ) {
 }

--- a/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/FormPublishRequest.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/FormPublishRequest.java
@@ -1,0 +1,19 @@
+package OneQ.OnSurvey.domain.survey.model.formRequest;
+
+import OneQ.OnSurvey.domain.survey.model.request.ScreeningRequest;
+import OneQ.OnSurvey.domain.survey.model.request.SurveyFormRequest;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+
+public record FormPublishRequest(
+        @Schema(description = "스크리닝 문항 (선택)")
+        @Valid
+        ScreeningRequest screening,
+
+        @Schema(description = "세그먼트 및 가격 정보")
+        @NotNull
+        @Valid
+        SurveyFormRequest surveyForm
+) {
+}

--- a/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/FormRequestDto.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/FormRequestDto.java
@@ -2,12 +2,17 @@ package OneQ.OnSurvey.domain.survey.model.formRequest;
 
 import OneQ.OnSurvey.domain.survey.entity.FormRequest;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 
 public record FormRequestDto(
         @Schema(description = "폼 링크", example = "https://docs.google.com/forms/d/e/1FAIpQLSfD.../viewform")
+        @NotBlank
         String formLink,
 
         @Schema(description = "신청자 이메일", example = "test@gmail.com")
+        @Email
+        @NotBlank
         String requesterEmail
 ) {
     public FormRequest toEntity() {

--- a/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/FormRequestDto.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/FormRequestDto.java
@@ -1,21 +1,34 @@
 package OneQ.OnSurvey.domain.survey.model.formRequest;
 
 import OneQ.OnSurvey.domain.survey.entity.FormRequest;
+import OneQ.OnSurvey.domain.survey.model.request.ScreeningRequest;
+import OneQ.OnSurvey.domain.survey.model.request.SurveyFormRequest;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.hibernate.validator.constraints.URL;
 
 public record FormRequestDto(
-        @Schema(description = "폼 링크", example = "https://docs.google.com/forms/d/e/1FAIpQLSfD.../viewform")
-        @NotBlank
-        String formLink,
+    @Schema(description = "폼 링크", example = "https://docs.google.com/forms/d/e/1FAIpQLSfD.../viewform")
+    @URL @NotBlank
+    String formLink,
 
-        @Schema(description = "신청자 이메일", example = "test@gmail.com")
-        @Email
-        @NotBlank
-        String requesterEmail
+    @Schema(description = "신청자 이메일", example = "test@gmail.com")
+    @Email @NotBlank
+    String requesterEmail,
+
+    @Schema(description = "스크리닝 문항 (선택)")
+    @Valid
+    ScreeningRequest screening,
+
+    @Schema(description = "세그먼트 및 가격 정보")
+    @NotNull
+    @Valid
+    SurveyFormRequest surveyForm
 ) {
-    public FormRequest toEntity() {
-        return FormRequest.createRequest(formLink, requesterEmail);
+    public FormRequest toEntity(long userKey) {
+        return FormRequest.createRequest(formLink, requesterEmail, userKey);
     }
 }

--- a/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/FormRequestDto.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/FormRequestDto.java
@@ -1,5 +1,6 @@
 package OneQ.OnSurvey.domain.survey.model.formRequest;
 
+import OneQ.OnSurvey.domain.member.value.Interest;
 import OneQ.OnSurvey.domain.survey.entity.FormRequest;
 import OneQ.OnSurvey.domain.survey.model.request.ScreeningRequest;
 import OneQ.OnSurvey.domain.survey.model.request.SurveyFormRequest;
@@ -9,6 +10,8 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import org.hibernate.validator.constraints.URL;
+
+import java.util.Set;
 
 public record FormRequestDto(
     @Schema(description = "폼 링크", example = "https://docs.google.com/forms/d/e/1FAIpQLSfD.../viewform")
@@ -26,7 +29,14 @@ public record FormRequestDto(
     @Schema(description = "세그먼트 및 가격 정보")
     @NotNull
     @Valid
-    SurveyFormRequest surveyForm
+    SurveyFormRequest surveyForm,
+
+    @Schema(
+        description = "관심사 목록",
+        example = "[\"CAREER\", \"BUSINESS\", \"FINANCE\"]",
+        implementation = Interest.class
+    )
+    Set<Interest> interests
 ) {
     public FormRequest toEntity(long userKey) {
         return FormRequest.createRequest(formLink, requesterEmail, userKey);

--- a/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/FormRequestDto.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/FormRequestDto.java
@@ -3,35 +3,14 @@ package OneQ.OnSurvey.domain.survey.model.formRequest;
 import OneQ.OnSurvey.domain.survey.entity.FormRequest;
 import io.swagger.v3.oas.annotations.media.Schema;
 
-import java.time.LocalDate;
-
 public record FormRequestDto(
         @Schema(description = "폼 링크", example = "https://docs.google.com/forms/d/e/1FAIpQLSfD.../viewform")
         String formLink,
 
-        @Schema(description = "질문 수", example = "15")
-        Integer questionCount,
-
-        @Schema(description = "목표 응답 수", example = "100")
-        Integer targetResponseCount,
-
-        @Schema(description = "마감일", example = "2026-12-31")
-        LocalDate deadline,
-
         @Schema(description = "신청자 이메일", example = "test@gmail.com")
-        String requesterEmail,
-
-        @Schema(description = "가격", example = "9900")
-        Integer price
+        String requesterEmail
 ) {
     public FormRequest toEntity() {
-        return FormRequest.createRequest(
-                formLink,
-                questionCount,
-                targetResponseCount,
-                deadline,
-                requesterEmail,
-                price
-        );
+        return FormRequest.createRequest(formLink, requesterEmail);
     }
 }

--- a/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/FormRequestDto.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/FormRequestDto.java
@@ -14,7 +14,7 @@ import org.hibernate.validator.constraints.URL;
 import java.util.Set;
 
 public record FormRequestDto(
-    @Schema(description = "폼 링크", example = "https://docs.google.com/forms/d/e/1FAIpQLSfD.../viewform")
+    @Schema(description = "폼 링크", example = "https://docs.google.com/forms/d/1FAIpQLSfD.../edit")
     @URL @NotBlank
     String formLink,
 

--- a/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/FormRequestResponse.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/FormRequestResponse.java
@@ -2,16 +2,14 @@ package OneQ.OnSurvey.domain.survey.model.formRequest;
 
 import OneQ.OnSurvey.domain.survey.entity.FormRequest;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 public record FormRequestResponse(
         Long id,
         String formLink,
+        String requesterEmail,
         Integer questionCount,
         Integer targetResponseCount,
-        LocalDate deadline,
-        String requesterEmail,
         Integer price,
         Boolean isRegistered,
         Long registeredSurveyId,
@@ -21,10 +19,9 @@ public record FormRequestResponse(
         return new FormRequestResponse(
                 request.getId(),
                 request.getFormLink(),
+                request.getRequesterEmail(),
                 request.getQuestionCount(),
                 request.getTargetResponseCount(),
-                request.getDeadline(),
-                request.getRequesterEmail(),
                 request.getPrice(),
                 request.getIsRegistered(),
                 request.getRegisteredSurveyId(),

--- a/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/FormValidationAndStashResponse.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/FormValidationAndStashResponse.java
@@ -33,7 +33,6 @@ public record FormValidationAndStashResponse(
     public record Unconvertible(
         String title,
         String type,
-        int order,
         String reason
     ) { }
 }

--- a/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/FormValidationAndStashResponse.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/FormValidationAndStashResponse.java
@@ -1,0 +1,39 @@
+package OneQ.OnSurvey.domain.survey.model.formRequest;
+
+import java.util.List;
+
+public record FormValidationAndStashResponse(
+    int totalUrls,
+    int successCount,
+    List<Result> results
+) {
+
+    public record Result(
+        String url,
+        String status, // "SUCCESS", "FAIL"
+
+        // SUCCESS
+        Count counts,
+        List<Unconvertible> unconvertibleDetails,
+
+        // FAIL
+        String message
+    ) {
+        public boolean isSuccess() {
+            return "SUCCESS".equals(status);
+        }
+    }
+
+    public record Count(
+        int total,
+        int convertible,
+        int unconvertible
+    ) { }
+
+    public record Unconvertible(
+        String title,
+        String type,
+        int order,
+        String reason
+    ) { }
+}

--- a/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/FormValidationPayload.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/FormValidationPayload.java
@@ -1,0 +1,8 @@
+package OneQ.OnSurvey.domain.survey.model.formRequest;
+
+import java.util.List;
+
+public record FormValidationPayload(
+    List<String> urls,
+    String requesterEmail
+) { }

--- a/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/FormValidationRequestDto.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/FormValidationRequestDto.java
@@ -1,11 +1,17 @@
 package OneQ.OnSurvey.domain.survey.model.formRequest;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import org.hibernate.validator.constraints.URL;
 
 public record FormValidationRequestDto(
     @Schema(description = "폼 편집 링크", example = "https://docs.google.com/forms/d/1FAIpQLSfD.../edit")
+    @URL @NotBlank
     String formLink,
+
     @Schema(description = "신청자 이메일", example = "test@gmail.com")
+    @Email @NotBlank
     String requesterEmail
 ) {
 }

--- a/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/FormValidationRequestDto.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/FormValidationRequestDto.java
@@ -1,0 +1,11 @@
+package OneQ.OnSurvey.domain.survey.model.formRequest;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record FormValidationRequestDto(
+    @Schema(description = "폼 편집 링크", example = "https://docs.google.com/forms/d/1FAIpQLSfD.../edit")
+    String formLink,
+    @Schema(description = "신청자 이메일", example = "test@gmail.com")
+    String requesterEmail
+) {
+}

--- a/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/FormValidationResponse.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/FormValidationResponse.java
@@ -16,7 +16,6 @@ public record FormValidationResponse(
     public record Unconvertible(
         String title,
         String type,
-        int order,
         String reason
     ) { }
 
@@ -31,7 +30,6 @@ public record FormValidationResponse(
                         .map(u -> new Unconvertible(
                             u.title(),
                             u.type(),
-                            u.order(),
                             u.reason()
                         ))
                     .toList()

--- a/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/FormValidationResponse.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/FormValidationResponse.java
@@ -1,0 +1,44 @@
+package OneQ.OnSurvey.domain.survey.model.formRequest;
+
+import java.util.List;
+
+public record FormValidationResponse(
+    List<Result> results
+) {
+
+    public record Result(
+        int totalCount,
+        int convertible,
+        int unconvertible,
+        List<Unconvertible> details
+    ) { }
+
+    public record Unconvertible(
+        String title,
+        String type,
+        int order,
+        String reason
+    ) { }
+
+    public static FormValidationResponse from(FormValidationAndStashResponse dto) {
+        List<Result> results = dto.results().stream()
+            .map(r -> r.isSuccess()
+                ? new Result(
+                    r.counts().total(),
+                    r.counts().convertible(),
+                    r.counts().unconvertible(),
+                    r.unconvertibleDetails().stream()
+                        .map(u -> new Unconvertible(
+                            u.title(),
+                            u.type(),
+                            u.order(),
+                            u.reason()
+                        ))
+                    .toList()
+                )
+                : null
+            ).toList();
+
+        return new FormValidationResponse(results);
+    }
+}

--- a/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/FormValidationResponse.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/FormValidationResponse.java
@@ -20,19 +20,23 @@ public record FormValidationResponse(
     ) { }
 
     public static FormValidationResponse from(FormValidationAndStashResponse dto) {
-        List<Result> results = dto.results().stream()
+        List<FormValidationAndStashResponse.Result> sourceResults = dto.results() == null ? List.of() : dto.results();
+
+        List<Result> results = sourceResults.stream()
             .map(r -> r.isSuccess()
                 ? new Result(
                     r.counts().total(),
                     r.counts().convertible(),
                     r.counts().unconvertible(),
-                    r.unconvertibleDetails().stream()
-                        .map(u -> new Unconvertible(
-                            u.title(),
-                            u.type(),
-                            u.reason()
-                        ))
-                    .toList()
+                    r.unconvertibleDetails() != null
+                        ? r.unconvertibleDetails().stream()
+                            .map(u -> new Unconvertible(
+                                u.title(),
+                                u.type(),
+                                u.reason()
+                            ))
+                        .toList()
+                        : List.of()
                 )
                 : null
             ).toList();

--- a/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/event/FormRequestConversionEvent.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/event/FormRequestConversionEvent.java
@@ -1,10 +1,18 @@
 package OneQ.OnSurvey.domain.survey.model.formRequest.event;
 
+import OneQ.OnSurvey.domain.survey.model.request.ScreeningRequest;
+import OneQ.OnSurvey.domain.survey.model.request.SurveyFormRequest;
+
 import java.util.List;
 
 public record FormRequestConversionEvent (
     Long requestId,
-    String email,
-    List<String> formUrls
+    Long userKey,
+    Long memberId,
+    List<String> formUrls,
+
+    // TODO 무거운 이벤트를 requestId, surveyId, userKey, formUrls만 보내도록 설문을 선생성 후 데이터를 추가하도록 로직 수정 필요
+    ScreeningRequest screening,
+    SurveyFormRequest surveyForm
 ) {
 }

--- a/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/event/FormRequestConversionEvent.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/event/FormRequestConversionEvent.java
@@ -1,9 +1,11 @@
 package OneQ.OnSurvey.domain.survey.model.formRequest.event;
 
+import OneQ.OnSurvey.domain.member.value.Interest;
 import OneQ.OnSurvey.domain.survey.model.request.ScreeningRequest;
 import OneQ.OnSurvey.domain.survey.model.request.SurveyFormRequest;
 
 import java.util.List;
+import java.util.Set;
 
 public record FormRequestConversionEvent (
     Long requestId,
@@ -13,6 +15,7 @@ public record FormRequestConversionEvent (
 
     // TODO 무거운 이벤트를 requestId, surveyId, userKey, formUrls만 보내도록 설문을 선생성 후 데이터를 추가하도록 로직 수정 필요
     ScreeningRequest screening,
-    SurveyFormRequest surveyForm
+    SurveyFormRequest surveyForm,
+    Set<Interest> interests
 ) {
 }

--- a/src/main/java/OneQ/OnSurvey/domain/survey/service/form/SurveyFormFacade.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/service/form/SurveyFormFacade.java
@@ -79,7 +79,6 @@ public class SurveyFormFacade implements SurveyFormUseCase {
 
         List<OptionUpsertDto> optionUpsertDtoList =
                 buildOptionUpsertDtosFromSavedQuestions(savedQuestionUpsertDto, requestQuestionUpsertDto);
-        log.info("[FORM:updateSurvey] 문항 별 보기 리스트: {}", optionUpsertDtoList);
 
         optionUpsertDtoList = questionCommand.upsertChoiceOptionList(optionUpsertDtoList);
         Map<Long, OptionUpsertDto> optionDtoMap = mapOptionsByQuestionId(optionUpsertDtoList);

--- a/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormCommandService.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormCommandService.java
@@ -1,6 +1,9 @@
 package OneQ.OnSurvey.domain.survey.service.formRequest;
 
 import OneQ.OnSurvey.domain.survey.entity.FormRequest;
+import OneQ.OnSurvey.domain.survey.model.formRequest.FormValidationAndStashResponse;
+import OneQ.OnSurvey.domain.survey.model.formRequest.FormValidationRequestDto;
+import OneQ.OnSurvey.domain.survey.model.formRequest.FormValidationResponse;
 import OneQ.OnSurvey.domain.survey.model.formRequest.event.FormRequestConversionEvent;
 import OneQ.OnSurvey.domain.survey.model.formRequest.FormRequestDto;
 import OneQ.OnSurvey.domain.survey.repository.formRequest.FormRequestRepository;
@@ -21,6 +24,7 @@ import static OneQ.OnSurvey.domain.survey.SurveyErrorCode.FORM_REQUEST_NOT_FOUND
 public class FormCommandService implements FormCreator, FormUpdater {
 
     private final ApplicationEventPublisher eventPublisher;
+    private final FormRequestLambda formRequestLambda;
     private final FormRequestRepository formRequestRepository;
     private final SurveyQueryService surveyQueryService;
 
@@ -45,5 +49,19 @@ public class FormCommandService implements FormCreator, FormUpdater {
                 .orElseThrow(() -> new CustomException(FORM_REQUEST_NOT_FOUND));
 
         request.markAsRegistered(surveyId);
+    }
+
+    /**
+     * 구글폼 링크 유효성을 검사한 뒤, 변환 가능/불가능한 문항 수를 각각 반환하고 반환 불가능한 문항에 대해서는 그 사유를 반환
+     * 유효성 검사가 이루어진 데이터를 s3에 stash한다.
+     *
+     * @param dto 구글폼 링크 유효성 검사를 진행할 formLink는 필수로 가지고 있는 DTO
+     * @return 변환된 문항 수 / 변환되지 않은 문항 및 사유
+     */
+    @Override
+    public FormValidationResponse validationFormRequestLink(FormValidationRequestDto dto) {
+        FormValidationAndStashResponse formCount = formRequestLambda.validateAndStashFormRequest(dto.formLink(), dto.requesterEmail());
+
+        return FormValidationResponse.from(formCount);
     }
 }

--- a/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormCommandService.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormCommandService.java
@@ -2,9 +2,11 @@ package OneQ.OnSurvey.domain.survey.service.formRequest;
 
 import OneQ.OnSurvey.domain.member.dto.MemberSearchResult;
 import OneQ.OnSurvey.domain.member.service.MemberFinder;
+import OneQ.OnSurvey.domain.survey.SurveyErrorCode;
 import OneQ.OnSurvey.domain.survey.entity.FormRequest;
 import OneQ.OnSurvey.domain.survey.model.formRequest.FormPublishRequest;
 import OneQ.OnSurvey.domain.survey.model.formRequest.FormValidationAndStashResponse;
+import OneQ.OnSurvey.domain.survey.model.formRequest.FormValidationPayload;
 import OneQ.OnSurvey.domain.survey.model.formRequest.FormValidationRequestDto;
 import OneQ.OnSurvey.domain.survey.model.formRequest.FormValidationResponse;
 import OneQ.OnSurvey.domain.survey.model.formRequest.event.FormRequestConversionEvent;
@@ -15,6 +17,7 @@ import OneQ.OnSurvey.domain.survey.service.command.SurveyCommand;
 import OneQ.OnSurvey.domain.survey.service.query.SurveyQueryService;
 import OneQ.OnSurvey.global.common.exception.CustomException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,6 +26,7 @@ import java.util.List;
 
 import static OneQ.OnSurvey.domain.survey.SurveyErrorCode.*;
 
+@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -36,15 +40,18 @@ public class FormCommandService implements FormCreator, FormUpdater, FormPublish
     private final SurveyCommand surveyCommand;
 
     @Override
-    public Long createFormRequest(FormRequestDto dto) {
-        FormRequest request = dto.toEntity();
+    public Long createFormRequest(Long userKey, Long memberId, FormRequestDto dto) {
+        FormRequest request = dto.toEntity(userKey);
         FormRequest savedRequest = formRequestRepository.save(request);
 
         eventPublisher.publishEvent(new FormRequestConversionEvent(
             savedRequest.getId(),
-            savedRequest.getRequesterEmail(),
-            List.of(savedRequest.getFormLink()))
-        );
+            userKey,
+            memberId,
+            List.of(savedRequest.getFormLink()),
+            dto.screening(),
+            dto.surveyForm()
+        ));
         return savedRequest.getId();
     }
 
@@ -95,8 +102,13 @@ public class FormCommandService implements FormCreator, FormUpdater, FormPublish
      */
     @Override
     public FormValidationResponse validationFormRequestLink(FormValidationRequestDto dto) {
-        FormValidationAndStashResponse formCount = formRequestLambda.validateAndStashFormRequest(dto.formLink(), dto.requesterEmail());
+        FormValidationPayload payload = new FormValidationPayload(List.of(dto.formLink()), dto.requesterEmail());
+        FormValidationAndStashResponse validationResult = formRequestLambda.validateAndStashFormRequest(payload);
 
-        return FormValidationResponse.from(formCount);
+        if (validationResult == null || validationResult.successCount() == 0) {
+            log.warn("[FormCommandService:validationFormRequestLink] 구글폼 링크가 유효하지 않음 - URL: {}", dto.formLink());
+            throw new CustomException(SurveyErrorCode.FORM_INVALID);
+        }
+        return FormValidationResponse.from(validationResult);
     }
 }

--- a/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormCommandService.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormCommandService.java
@@ -1,9 +1,14 @@
 package OneQ.OnSurvey.domain.survey.service.formRequest;
 
+import OneQ.OnSurvey.domain.member.dto.MemberSearchResult;
+import OneQ.OnSurvey.domain.member.service.MemberFinder;
 import OneQ.OnSurvey.domain.survey.entity.FormRequest;
-import OneQ.OnSurvey.domain.survey.model.formRequest.event.FormRequestConversionEvent;
+import OneQ.OnSurvey.domain.survey.model.formRequest.FormPublishRequest;
 import OneQ.OnSurvey.domain.survey.model.formRequest.FormRequestDto;
+import OneQ.OnSurvey.domain.survey.model.formRequest.event.FormRequestConversionEvent;
+import OneQ.OnSurvey.domain.survey.model.response.SurveyFormResponse;
 import OneQ.OnSurvey.domain.survey.repository.formRequest.FormRequestRepository;
+import OneQ.OnSurvey.domain.survey.service.command.SurveyCommand;
 import OneQ.OnSurvey.domain.survey.service.query.SurveyQueryService;
 import OneQ.OnSurvey.global.common.exception.CustomException;
 import lombok.RequiredArgsConstructor;
@@ -13,16 +18,18 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-import static OneQ.OnSurvey.domain.survey.SurveyErrorCode.FORM_REQUEST_NOT_FOUND;
+import static OneQ.OnSurvey.domain.survey.SurveyErrorCode.*;
 
 @Service
 @Transactional
 @RequiredArgsConstructor
-public class FormCommandService implements FormCreator, FormUpdater {
+public class FormCommandService implements FormCreator, FormUpdater, FormPublisher {
 
     private final ApplicationEventPublisher eventPublisher;
     private final FormRequestRepository formRequestRepository;
     private final SurveyQueryService surveyQueryService;
+    private final MemberFinder memberFinder;
+    private final SurveyCommand surveyCommand;
 
     @Override
     public Long createFormRequest(FormRequestDto dto) {
@@ -38,12 +45,40 @@ public class FormCommandService implements FormCreator, FormUpdater {
     }
 
     @Override
-    public void markAsRegistered(Long requestId, Long surveyId) {
+    public void markAsRegistered(Long requestId, Long surveyId, Integer questionCount) {
         surveyQueryService.getSurveyById(surveyId);
 
         FormRequest request = formRequestRepository.findById(requestId)
                 .orElseThrow(() -> new CustomException(FORM_REQUEST_NOT_FOUND));
 
-        request.markAsRegistered(surveyId);
+        request.markAsRegistered(surveyId, questionCount);
+    }
+
+    @Override
+    public SurveyFormResponse publishFormRequest(Long requestId, FormPublishRequest publishRequest) {
+        FormRequest formRequest = formRequestRepository.findById(requestId)
+                .orElseThrow(() -> new CustomException(FORM_REQUEST_NOT_FOUND));
+
+        if (!formRequest.getIsRegistered() || formRequest.getRegisteredSurveyId() == null) {
+            throw new CustomException(FORM_REQUEST_NOT_YET_REGISTERED);
+        }
+
+        Long surveyId = formRequest.getRegisteredSurveyId();
+
+        List<MemberSearchResult> members = memberFinder.searchMembers(formRequest.getRequesterEmail(), null, null, null);
+        if (members.size() != 1) {
+            throw new CustomException(FORM_REQUEST_MEMBER_NOT_FOUND);
+        }
+        Long userKey = members.getFirst().userKey();
+
+        if (publishRequest.screening() != null) {
+            surveyCommand.upsertScreening(
+                surveyId,
+                publishRequest.screening().content(),
+                publishRequest.screening().answer()
+            );
+        }
+
+        return surveyCommand.submitSurvey(userKey, surveyId, publishRequest.surveyForm());
     }
 }

--- a/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormCommandService.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormCommandService.java
@@ -50,7 +50,8 @@ public class FormCommandService implements FormCreator, FormUpdater, FormPublish
             memberId,
             List.of(savedRequest.getFormLink()),
             dto.screening(),
-            dto.surveyForm()
+            dto.surveyForm(),
+            dto.interests()
         ));
         return savedRequest.getId();
     }

--- a/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormCreator.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormCreator.java
@@ -5,6 +5,6 @@ import OneQ.OnSurvey.domain.survey.model.formRequest.FormValidationResponse;
 import OneQ.OnSurvey.domain.survey.model.formRequest.FormRequestDto;
 
 public interface FormCreator {
-    Long createFormRequest(FormRequestDto dto);
+    Long createFormRequest(Long userKey, Long memberId, FormRequestDto dto);
     FormValidationResponse validationFormRequestLink(FormValidationRequestDto dto);
 }

--- a/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormCreator.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormCreator.java
@@ -1,7 +1,10 @@
 package OneQ.OnSurvey.domain.survey.service.formRequest;
 
+import OneQ.OnSurvey.domain.survey.model.formRequest.FormValidationRequestDto;
+import OneQ.OnSurvey.domain.survey.model.formRequest.FormValidationResponse;
 import OneQ.OnSurvey.domain.survey.model.formRequest.FormRequestDto;
 
 public interface FormCreator {
     Long createFormRequest(FormRequestDto dto);
+    FormValidationResponse validationFormRequestLink(FormValidationRequestDto dto);
 }

--- a/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormEventListener.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormEventListener.java
@@ -1,5 +1,6 @@
 package OneQ.OnSurvey.domain.survey.service.formRequest;
 
+import OneQ.OnSurvey.domain.member.value.Interest;
 import OneQ.OnSurvey.domain.question.model.QuestionType;
 import OneQ.OnSurvey.domain.question.model.dto.OptionDto;
 import OneQ.OnSurvey.domain.question.model.dto.OptionUpsertDto;
@@ -29,6 +30,7 @@ import org.springframework.transaction.event.TransactionalEventListener;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
@@ -92,6 +94,11 @@ public class FormEventListener {
                                     event.screening().content(),
                                     event.screening().answer()
                                 );
+                            }
+                            if (event.interests() != null && !event.interests().isEmpty()) {
+                                surveyCommand.upsertInterest(surveyId, event.interests());
+                            } else {
+                                surveyCommand.upsertInterest(surveyId, Set.of(Interest.BUSINESS));
                             }
                             surveyCommand.submitSurvey(event.userKey(), surveyId, event.surveyForm());
 

--- a/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormEventListener.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormEventListener.java
@@ -1,0 +1,265 @@
+package OneQ.OnSurvey.domain.survey.service.formRequest;
+
+import OneQ.OnSurvey.domain.question.model.QuestionType;
+import OneQ.OnSurvey.domain.question.model.dto.OptionDto;
+import OneQ.OnSurvey.domain.question.model.dto.OptionUpsertDto;
+import OneQ.OnSurvey.domain.question.model.dto.QuestionUpsertDto;
+import OneQ.OnSurvey.domain.question.model.dto.SectionDto;
+import OneQ.OnSurvey.domain.question.service.QuestionCommand;
+import OneQ.OnSurvey.domain.survey.SurveyErrorCode;
+import OneQ.OnSurvey.domain.survey.entity.FormRequest;
+import OneQ.OnSurvey.domain.survey.model.formRequest.FormConversionPayload;
+import OneQ.OnSurvey.domain.survey.model.formRequest.FormConversionResponse;
+import OneQ.OnSurvey.domain.survey.model.formRequest.event.FormRequestConversionEvent;
+import OneQ.OnSurvey.domain.survey.model.request.SurveyFormCreateRequest;
+import OneQ.OnSurvey.domain.survey.model.response.SurveyFormResponse;
+import OneQ.OnSurvey.domain.survey.repository.formRequest.FormRequestRepository;
+import OneQ.OnSurvey.domain.survey.service.command.SurveyCommand;
+import OneQ.OnSurvey.global.common.exception.CustomException;
+import OneQ.OnSurvey.global.infra.discord.notifier.AlertNotifier;
+import OneQ.OnSurvey.global.infra.discord.notifier.dto.SurveyConversionAlert;
+import OneQ.OnSurvey.global.infra.transaction.TransactionHandler;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class FormEventListener {
+
+    private final AlertNotifier alertNotifier;
+    private final TransactionHandler transactionHandler;
+
+    private final FormRequestLambda formRequestLambda;
+    private final SurveyCommand surveyCommand;
+    private final QuestionCommand questionCommand;
+
+    private final FormRequestRepository formRequestRepository;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void convertGoogleFormIntoSurvey(FormRequestConversionEvent event) {
+        log.info("[FormEventListener] 구글폼 변환 시작 - requestId: {}, formUrl: {}", event.requestId(), event.formUrls());
+
+        FormConversionPayload payload = new FormConversionPayload(event.requestId(), event.formUrls());
+        FormConversionResponse response = formRequestLambda.convertGoogleFormIntoSurvey(payload);
+
+        if (response == null || response.results() == null) {
+            log.error("[FormRequestLambda] 구글폼 변환 실패 - 응답이 null입니다. requestId: {}", event.requestId());
+            alertNotifier.sendSurveyConversionAsync(
+                response == null
+                    ? SurveyConversionAlert.error(1, 0, "변환 요청에 대한 응답이 null입니다.")
+                    : SurveyConversionAlert.error(response.totalCount(), response.successCount(), response.error())
+            );
+            throw new CustomException(SurveyErrorCode.FORM_CONVERSION_FAILED);
+        }
+
+        List<SurveyConversionAlert.SurveyDetails> detailList = new ArrayList<>();
+        response.results().forEach(result -> {
+            if (result.isSuccess()) {
+                try {
+                    detailList.add(
+                        transactionHandler.runInTransaction(() -> {
+                            Long surveyId = createSurveyFromConversionResult(result, event.memberId());
+                            int questionCount = result.survey().sections() != null
+                                ? result.survey().sections().stream()
+                                .mapToInt(s -> s.questions() != null ? s.questions().size() : 0)
+                                .sum()
+                                : 0;
+                            FormRequest request = formRequestRepository.findById(event.requestId())
+                                .orElseThrow(() -> new CustomException(SurveyErrorCode.FORM_REQUEST_NOT_FOUND));
+                            request.markAsRegistered(surveyId, questionCount);
+
+                            log.info("[FormRequestLambda] 구글폼 변환 성공 - requestId: {}, surveyId: {}, questionCount: {}", event.requestId(), surveyId, questionCount);
+                            if (result.unsupportedQuestions() != null && !result.unsupportedQuestions().isEmpty()) {
+                                log.warn("[FormRequestLambda] 지원하지 않는 문항 존재 - requestId: {}, count: {}",
+                                    event.requestId(), result.unsupportedQuestions().size());
+                            }
+
+                            if (event.screening() != null) {
+                                surveyCommand.upsertScreening(
+                                    surveyId,
+                                    event.screening().content(),
+                                    event.screening().answer()
+                                );
+                            }
+                            surveyCommand.submitSurvey(event.userKey(), surveyId, event.surveyForm());
+
+                            return SurveyConversionAlert.SurveyDetails.success(
+                                result.url(),
+                                result.survey().title(),
+                                surveyId,
+                                event.memberId(),
+                                questionCount,
+                                result.unsupportedQuestions() != null ? result.unsupportedQuestions().stream()
+                                    .map(q -> new SurveyConversionAlert.SurveyDetails.UnsupportedQuestion(q.order(), q.type(), q.reason()))
+                                    .toList() : List.of()
+                            );
+                        })
+                    );
+                } catch (Exception e) {
+                    log.error("[FormRequestLambda] 설문 생성 중 오류 발생 - requestId: {}, error: {}",
+                        event.requestId(), e.getMessage(), e);
+                    detailList.add(SurveyConversionAlert.SurveyDetails.failure(result.url(), "설문 생성 중 오류가 발생했습니다."));
+                }
+            } else {
+                log.error("[FormRequestLambda] 구글폼 변환 실패 - requestId: {}, url: {}, message: {}",
+                    event.requestId(), result.url(), result.message());
+                detailList.add(SurveyConversionAlert.SurveyDetails.failure(result.url(), result.message()));
+            }
+        });
+        alertNotifier.sendSurveyConversionAsync(
+            SurveyConversionAlert.success(response.totalCount(), response.successCount(), detailList)
+        );
+    }
+
+    private Long createSurveyFromConversionResult(FormConversionResponse.Result result, Long memberId) {
+        FormConversionResponse.Survey survey = result.survey();
+
+        // 1. 설문 생성
+        SurveyFormCreateRequest surveyRequest = new SurveyFormCreateRequest(
+            survey.title(),
+            survey.description()
+        );
+        SurveyFormResponse surveyResponse = surveyCommand.upsertSurvey(memberId, null, surveyRequest);
+        Long surveyId = surveyResponse.surveyId();
+
+        // 2. 섹션 생성
+        if (survey.sections() != null && !survey.sections().isEmpty()) {
+            List<SectionDto> sectionDtoList = survey.sections().stream()
+                .map(section -> new SectionDto(
+                    null,
+                    section.title(),
+                    section.description(),
+                    section.order(),
+                    section.nextSectionOrder() != null ? section.nextSectionOrder() : 0
+                ))
+                .toList();
+
+            questionCommand.upsertSections(surveyId, sectionDtoList);
+        }
+
+        // 3. 문항 생성
+        List<QuestionUpsertDto.UpsertInfo> questionUpsertInfoList = new ArrayList<>();
+        AtomicInteger questionOrder = new AtomicInteger(0);
+
+        if (survey.sections() != null) {
+            for (FormConversionResponse.Section section : survey.sections()) {
+                if (section.questions() != null) {
+                    for (FormConversionResponse.Question question : section.questions()) {
+                        QuestionType questionType = mapQuestionType(question.type());
+                        if (questionType == null) {
+                            continue;
+                        }
+
+                        QuestionUpsertDto.UpsertInfo.UpsertInfoBuilder builder = QuestionUpsertDto.UpsertInfo.builder()
+                            .questionId(null)
+                            .title(question.title())
+                            .description(question.description())
+                            .isRequired(question.required())
+                            .questionType(questionType)
+                            .questionOrder(questionOrder.getAndIncrement())
+                            .imageUrl(question.imageUrl())
+                            .section(section.order());
+
+                        // Choice 타입인 경우 옵션 설정
+                        if (questionType == QuestionType.CHOICE && question.options() != null) {
+                            boolean hasOtherOption = question.options().stream()
+                                .anyMatch(FormConversionResponse.Option::isOther);
+                            boolean isSectionDecidable = question.options().stream()
+                                .anyMatch(opt -> opt.goToSectionOrder() != null);
+                            int maxChoice = switch (question.type().toUpperCase()) {
+                                case "CHECKBOX" -> question.options().size(); // 체크박스는 여러 개 선택 가능
+                                case "DROPDOWN", "MULTIPLE_CHOICE" -> 1; // 드롭다운, 객관식은 하나만 선택 가능
+                                default -> 1; // 기본적으로 하나만 선택 가능하도록 설정
+                            };
+
+                            builder.maxChoice(maxChoice)
+                                .hasNoneOption(false)
+                                .hasCustomInput(hasOtherOption)
+                                .isSectionDecidable(isSectionDecidable)
+                                .options(question.options().stream()
+                                    .filter(opt -> !opt.isOther())
+                                    .map(opt -> OptionDto.builder()
+                                        .content(opt.text())
+                                        .nextSection(opt.goToSectionOrder())
+                                        .imageUrl(opt.imageUrl())
+                                        .build())
+                                    .toList());
+                        }
+
+                        questionUpsertInfoList.add(builder.build());
+                    }
+                }
+            }
+        }
+
+        if (!questionUpsertInfoList.isEmpty()) {
+            QuestionUpsertDto questionUpsertDto = QuestionUpsertDto.builder()
+                .surveyId(surveyId)
+                .upsertInfoList(questionUpsertInfoList)
+                .build();
+
+            QuestionUpsertDto savedQuestions = questionCommand.upsertQuestionList(questionUpsertDto);
+
+            // 4. Choice 문항의 옵션 저장
+            List<OptionUpsertDto> optionUpsertDtoList = new ArrayList<>();
+            List<QuestionUpsertDto.UpsertInfo> savedInfoList = savedQuestions.getUpsertInfoList();
+            Map<Integer, QuestionUpsertDto.UpsertInfo> originalInfoMap = questionUpsertInfoList.stream()
+                .collect(java.util.stream.Collectors.toMap(QuestionUpsertDto.UpsertInfo::getQuestionOrder, Function.identity()));
+
+            for (QuestionUpsertDto.UpsertInfo savedInfo : savedInfoList) {
+                QuestionUpsertDto.UpsertInfo originalInfo = originalInfoMap.get(savedInfo.getQuestionOrder());
+
+                if (savedInfo.getQuestionType() == QuestionType.CHOICE && originalInfo.getOptions() != null) {
+                    List<OptionDto> options = originalInfo.getOptions().stream()
+                        .map(opt -> OptionDto.builder()
+                            .questionId(savedInfo.getQuestionId())
+                            .content(opt.getContent())
+                            .nextSection(opt.getNextSection())
+                            .imageUrl(opt.getImageUrl())
+                            .build())
+                        .toList();
+
+                    optionUpsertDtoList.add(OptionUpsertDto.builder()
+                        .questionId(savedInfo.getQuestionId())
+                        .optionInfoList(options)
+                        .build());
+                }
+            }
+
+            if (!optionUpsertDtoList.isEmpty()) {
+                questionCommand.upsertChoiceOptionList(optionUpsertDtoList);
+            }
+        }
+
+        return surveyId;
+    }
+
+    private QuestionType mapQuestionType(String googleFormType) {
+        if (googleFormType == null) {
+            return null;
+        }
+
+        return switch (googleFormType.toUpperCase()) {
+            case "MULTIPLE_CHOICE", "CHECKBOX" -> QuestionType.CHOICE;
+            case "SHORT_ANSWER", "SHORT" -> QuestionType.SHORT;
+            case "PARAGRAPH", "LONG" -> QuestionType.LONG;
+            case "LINEAR_SCALE", "SCALE" -> QuestionType.RATING;
+            case "DATE" -> QuestionType.DATE;
+            case "NUMBER" -> QuestionType.NUMBER;
+            case "IMAGE" -> QuestionType.IMAGE;
+            default -> null;
+        };
+    }
+}

--- a/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormEventListener.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormEventListener.java
@@ -259,6 +259,7 @@ public class FormEventListener {
             case "DATE" -> QuestionType.DATE;
             case "NUMBER" -> QuestionType.NUMBER;
             case "IMAGE" -> QuestionType.IMAGE;
+            case "TITLE_DESCRIPTION" -> QuestionType.TITLE;
             default -> null;
         };
     }

--- a/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormPublisher.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormPublisher.java
@@ -1,0 +1,8 @@
+package OneQ.OnSurvey.domain.survey.service.formRequest;
+
+import OneQ.OnSurvey.domain.survey.model.formRequest.FormPublishRequest;
+import OneQ.OnSurvey.domain.survey.model.response.SurveyFormResponse;
+
+public interface FormPublisher {
+    SurveyFormResponse publishFormRequest(Long requestId, FormPublishRequest request);
+}

--- a/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormRequestLambda.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormRequestLambda.java
@@ -1,46 +1,23 @@
 package OneQ.OnSurvey.domain.survey.service.formRequest;
 
-import OneQ.OnSurvey.domain.member.dto.MemberSearchResult;
-import OneQ.OnSurvey.domain.member.service.MemberFinder;
-import OneQ.OnSurvey.domain.question.model.QuestionType;
-import OneQ.OnSurvey.domain.question.model.dto.OptionDto;
-import OneQ.OnSurvey.domain.question.model.dto.OptionUpsertDto;
-import OneQ.OnSurvey.domain.question.model.dto.QuestionUpsertDto;
-import OneQ.OnSurvey.domain.question.model.dto.SectionDto;
-import OneQ.OnSurvey.domain.question.service.QuestionCommand;
 import OneQ.OnSurvey.domain.survey.SurveyErrorCode;
-import OneQ.OnSurvey.domain.survey.entity.FormRequest;
 import OneQ.OnSurvey.domain.survey.model.formRequest.FormConversionPayload;
 import OneQ.OnSurvey.domain.survey.model.formRequest.FormConversionResponse;
 import OneQ.OnSurvey.domain.survey.model.formRequest.FormValidationAndStashResponse;
 import OneQ.OnSurvey.domain.survey.model.formRequest.FormValidationPayload;
-import OneQ.OnSurvey.domain.survey.model.formRequest.event.FormRequestConversionEvent;
-import OneQ.OnSurvey.domain.survey.model.request.SurveyFormCreateRequest;
-import OneQ.OnSurvey.domain.survey.model.response.SurveyFormResponse;
-import OneQ.OnSurvey.domain.survey.repository.formRequest.FormRequestRepository;
-import OneQ.OnSurvey.domain.survey.service.command.SurveyCommand;
 import OneQ.OnSurvey.global.common.exception.CustomException;
 import OneQ.OnSurvey.global.infra.discord.notifier.AlertNotifier;
 import OneQ.OnSurvey.global.infra.discord.notifier.dto.SurveyConversionAlert;
-import OneQ.OnSurvey.global.infra.transaction.TransactionHandler;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionPhase;
-import org.springframework.transaction.event.TransactionalEventListener;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.util.retry.Retry;
 
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Function;
 
 @Slf4j
 @Component
@@ -55,23 +32,10 @@ public class FormRequestLambda {
     private String validationUrl;
 
     private final AlertNotifier alertNotifier;
-    private final TransactionHandler transactionHandler;
     @Qualifier("lambdaWebClient")
     private final WebClient webClient;
 
-    private final MemberFinder memberFinder;
-    private final SurveyCommand surveyCommand;
-    private final QuestionCommand questionCommand;
-
-    private final FormRequestRepository formRequestRepository;
-
-    @Async
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void convertGoogleFormIntoSurvey(FormRequestConversionEvent event) {
-        log.info("[FormRequestLambda] 구글폼 변환 시작 - requestId: {}, formUrl: {}", event.requestId(), event.formUrls());
-
-        FormConversionPayload payload = new FormConversionPayload(event.formUrls());
-
+    public FormConversionResponse convertGoogleFormIntoSurvey(FormConversionPayload payload) {
         FormConversionResponse response = webClient.post()
             .uri(conversionUrl)
             .contentType(MediaType.APPLICATION_JSON)
@@ -81,7 +45,7 @@ public class FormRequestLambda {
             .timeout(Duration.ofSeconds(FORM_CONVERSION_REQUEST_TIMEOUT))
             .retryWhen(Retry.backoff(3, Duration.ofSeconds(3)))
             .onErrorMap(e -> {
-                log.error("[FormRequestLambda] 구글폼 변환 중 오류 발생 - requestId: {}, error: {}", event.requestId(), e.getMessage(), e);
+                log.error("[FormRequestLambda] 구글폼 변환 중 오류 발생 - requestId: {}, error: {}", payload.requestId(), e.getMessage(), e);
                 alertNotifier.sendSurveyConversionAsync(
                     SurveyConversionAlert.error(1, 0, "구글폼 변환 중 오류가 발생했습니다. error: " + e.getMessage())
                 );
@@ -89,75 +53,10 @@ public class FormRequestLambda {
             })
             .block();
 
-        if (response == null || response.results() == null) {
-            log.error("[FormRequestLambda] 구글폼 변환 실패 - 응답이 null입니다. requestId: {}", event.requestId());
-            alertNotifier.sendSurveyConversionAsync(
-                response == null
-                    ? SurveyConversionAlert.error(1, 0, "변환 요청에 대한 응답이 null입니다.")
-                    : SurveyConversionAlert.error(response.totalCount(), response.successCount(), response.error())
-            );
-            throw new CustomException(SurveyErrorCode.FORM_CONVERSION_FAILED);
-        }
-
-        List<MemberSearchResult> memberResultList = memberFinder.searchMembers(event.email(), null, null, null);
-        if (memberResultList.size() != 1) {
-            log.warn("[FormRequestLambda] 설문 생성 실패 - 요청자 이메일로 회원을 찾을 수 없습니다. email: {}", event.email());
-            throw new CustomException(SurveyErrorCode.FORM_REQUEST_NOT_FOUND);
-        }
-        Long memberId = memberResultList.getFirst().id();
-
-        List<SurveyConversionAlert.SurveyDetails> detailList = new ArrayList<>();
-        response.results().forEach(result -> {
-            if (result.isSuccess()) {
-                try {
-                    detailList.add(
-                        transactionHandler.runInTransaction(() -> {
-                            Long surveyId = createSurveyFromConversionResult(result, memberId);
-                            int questionCount = result.survey().sections() != null
-                                ? result.survey().sections().stream()
-                                .mapToInt(s -> s.questions() != null ? s.questions().size() : 0)
-                                .sum()
-                                : 0;
-                            FormRequest request = formRequestRepository.findById(event.requestId())
-                                .orElseThrow(() -> new CustomException(SurveyErrorCode.FORM_REQUEST_NOT_FOUND));
-                            request.markAsRegistered(surveyId, questionCount);
-
-                            log.info("[FormRequestLambda] 구글폼 변환 성공 - requestId: {}, surveyId: {}, questionCount: {}", event.requestId(), surveyId, questionCount);
-                            if (result.unsupportedQuestions() != null && !result.unsupportedQuestions().isEmpty()) {
-                                log.warn("[FormRequestLambda] 지원하지 않는 문항 존재 - requestId: {}, count: {}",
-                                    event.requestId(), result.unsupportedQuestions().size());
-                            }
-
-                            return SurveyConversionAlert.SurveyDetails.success(
-                                result.url(),
-                                result.survey().title(),
-                                surveyId,
-                                memberId,
-                                questionCount,
-                                result.unsupportedQuestions() != null ? result.unsupportedQuestions().stream()
-                                    .map(q -> new SurveyConversionAlert.SurveyDetails.UnsupportedQuestion(q.order(), q.type(), q.reason()))
-                                    .toList() : List.of()
-                            );
-                        })
-                    );
-                } catch (Exception e) {
-                    log.error("[FormRequestLambda] 설문 생성 중 오류 발생 - requestId: {}, error: {}",
-                        event.requestId(), e.getMessage(), e);
-                    detailList.add(SurveyConversionAlert.SurveyDetails.failure(result.url(), "설문 생성 중 오류가 발생했습니다."));
-                }
-            } else {
-                log.error("[FormRequestLambda] 구글폼 변환 실패 - requestId: {}, url: {}, message: {}",
-                    event.requestId(), result.url(), result.message());
-                detailList.add(SurveyConversionAlert.SurveyDetails.failure(result.url(), result.message()));
-            }
-        });
-        alertNotifier.sendSurveyConversionAsync(
-            SurveyConversionAlert.success(response.totalCount(), response.successCount(), detailList)
-        );
+        return response;
     }
 
-    public FormValidationAndStashResponse validateAndStashFormRequest(String formLink, String requesterEmail) {
-        FormValidationPayload payload = new FormValidationPayload(List.of(formLink), requesterEmail);
+    public FormValidationAndStashResponse validateAndStashFormRequest(FormValidationPayload payload) {
 
         FormValidationAndStashResponse response = webClient.post()
             .uri(validationUrl)
@@ -173,150 +72,6 @@ public class FormRequestLambda {
             })
             .block();
 
-        if (response == null || response.successCount() == 0) {
-            log.warn("[FormRequestLambda:validateAndStashFormRequest] 구글폼 링크가 유효하지 않음 - URLs: {}", payload.urls());
-            throw new CustomException(SurveyErrorCode.FORM_INVALID);
-        }
         return response;
-    }
-
-    private Long createSurveyFromConversionResult(FormConversionResponse.Result result, Long memberId) {
-        FormConversionResponse.Survey survey = result.survey();
-
-        // 1. 설문 생성
-        SurveyFormCreateRequest surveyRequest = new SurveyFormCreateRequest(
-            survey.title(),
-            survey.description()
-        );
-        SurveyFormResponse surveyResponse = surveyCommand.upsertSurvey(memberId, null, surveyRequest);
-        Long surveyId = surveyResponse.surveyId();
-
-        // 2. 섹션 생성
-        if (survey.sections() != null && !survey.sections().isEmpty()) {
-            List<SectionDto> sectionDtoList = survey.sections().stream()
-                .map(section -> new SectionDto(
-                    null,
-                    section.title(),
-                    section.description(),
-                    section.order(),
-                    section.nextSectionOrder() != null ? section.nextSectionOrder() : 0
-                ))
-                .toList();
-
-            questionCommand.upsertSections(surveyId, sectionDtoList);
-        }
-
-        // 3. 문항 생성
-        List<QuestionUpsertDto.UpsertInfo> questionUpsertInfoList = new ArrayList<>();
-        AtomicInteger questionOrder = new AtomicInteger(0);
-
-        if (survey.sections() != null) {
-            for (FormConversionResponse.Section section : survey.sections()) {
-                if (section.questions() != null) {
-                    for (FormConversionResponse.Question question : section.questions()) {
-                        QuestionType questionType = mapQuestionType(question.type());
-                        if (questionType == null) {
-                            continue;
-                        }
-
-                        QuestionUpsertDto.UpsertInfo.UpsertInfoBuilder builder = QuestionUpsertDto.UpsertInfo.builder()
-                            .questionId(null)
-                            .title(question.title())
-                            .description(question.description())
-                            .isRequired(question.required())
-                            .questionType(questionType)
-                            .questionOrder(questionOrder.getAndIncrement())
-                            .imageUrl(question.imageUrl())
-                            .section(section.order());
-
-                        // Choice 타입인 경우 옵션 설정
-                        if (questionType == QuestionType.CHOICE && question.options() != null) {
-                            boolean hasOtherOption = question.options().stream()
-                                .anyMatch(FormConversionResponse.Option::isOther);
-                            boolean isSectionDecidable = question.options().stream()
-                                .anyMatch(opt -> opt.goToSectionOrder() != null);
-                            int maxChoice = switch (question.type().toUpperCase()) {
-                                case "CHECKBOX" -> question.options().size(); // 체크박스는 여러 개 선택 가능
-                                case "DROPDOWN", "MULTIPLE_CHOICE" -> 1; // 드롭다운, 객관식은 하나만 선택 가능
-                                default -> 1; // 기본적으로 하나만 선택 가능하도록 설정
-                            };
-
-                            builder.maxChoice(maxChoice)
-                                .hasNoneOption(false)
-                                .hasCustomInput(hasOtherOption)
-                                .isSectionDecidable(isSectionDecidable)
-                                .options(question.options().stream()
-                                    .filter(opt -> !opt.isOther())
-                                    .map(opt -> OptionDto.builder()
-                                        .content(opt.text())
-                                        .nextSection(opt.goToSectionOrder())
-                                        .imageUrl(opt.imageUrl())
-                                        .build())
-                                    .toList());
-                        }
-
-                        questionUpsertInfoList.add(builder.build());
-                    }
-                }
-            }
-        }
-
-        if (!questionUpsertInfoList.isEmpty()) {
-            QuestionUpsertDto questionUpsertDto = QuestionUpsertDto.builder()
-                .surveyId(surveyId)
-                .upsertInfoList(questionUpsertInfoList)
-                .build();
-
-            QuestionUpsertDto savedQuestions = questionCommand.upsertQuestionList(questionUpsertDto);
-
-            // 4. Choice 문항의 옵션 저장
-            List<OptionUpsertDto> optionUpsertDtoList = new ArrayList<>();
-            List<QuestionUpsertDto.UpsertInfo> savedInfoList = savedQuestions.getUpsertInfoList();
-            Map<Integer, QuestionUpsertDto.UpsertInfo> originalInfoMap = questionUpsertInfoList.stream()
-                .collect(java.util.stream.Collectors.toMap(QuestionUpsertDto.UpsertInfo::getQuestionOrder, Function.identity()));
-
-            for (QuestionUpsertDto.UpsertInfo savedInfo : savedInfoList) {
-                QuestionUpsertDto.UpsertInfo originalInfo = originalInfoMap.get(savedInfo.getQuestionOrder());
-
-                if (savedInfo.getQuestionType() == QuestionType.CHOICE && originalInfo.getOptions() != null) {
-                    List<OptionDto> options = originalInfo.getOptions().stream()
-                        .map(opt -> OptionDto.builder()
-                            .questionId(savedInfo.getQuestionId())
-                            .content(opt.getContent())
-                            .nextSection(opt.getNextSection())
-                            .imageUrl(opt.getImageUrl())
-                            .build())
-                        .toList();
-
-                    optionUpsertDtoList.add(OptionUpsertDto.builder()
-                        .questionId(savedInfo.getQuestionId())
-                        .optionInfoList(options)
-                        .build());
-                }
-            }
-
-            if (!optionUpsertDtoList.isEmpty()) {
-                questionCommand.upsertChoiceOptionList(optionUpsertDtoList);
-            }
-        }
-
-        return surveyId;
-    }
-
-    private QuestionType mapQuestionType(String googleFormType) {
-        if (googleFormType == null) {
-            return null;
-        }
-
-        return switch (googleFormType.toUpperCase()) {
-            case "MULTIPLE_CHOICE", "CHECKBOX" -> QuestionType.CHOICE;
-            case "SHORT_ANSWER", "SHORT" -> QuestionType.SHORT;
-            case "PARAGRAPH", "LONG" -> QuestionType.LONG;
-            case "LINEAR_SCALE", "SCALE" -> QuestionType.RATING;
-            case "DATE" -> QuestionType.DATE;
-            case "NUMBER" -> QuestionType.NUMBER;
-            case "IMAGE" -> QuestionType.IMAGE;
-            default -> null;
-        };
     }
 }

--- a/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormRequestLambda.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormRequestLambda.java
@@ -106,9 +106,16 @@ public class FormRequestLambda {
                     detailList.add(
                         transactionHandler.runInTransaction(() -> {
                             Long surveyId = createSurveyFromConversionResult(result, memberId);
-                            formUpdater.markAsRegistered(event.requestId(), surveyId);
 
-                            log.info("[FormRequestLambda] 구글폼 변환 성공 - requestId: {}, surveyId: {}", event.requestId(), surveyId);
+                            int questionCount = result.survey().sections() != null
+                                ? result.survey().sections().stream()
+                                    .mapToInt(s -> s.questions() != null ? s.questions().size() : 0)
+                                    .sum()
+                                : 0;
+
+                            formUpdater.markAsRegistered(event.requestId(), surveyId, questionCount);
+
+                            log.info("[FormRequestLambda] 구글폼 변환 성공 - requestId: {}, surveyId: {}, questionCount: {}", event.requestId(), surveyId, questionCount);
 
                             if (result.unsupportedQuestions() != null && !result.unsupportedQuestions().isEmpty()) {
                                 log.warn("[FormRequestLambda] 지원하지 않는 문항 존재 - requestId: {}, count: {}",
@@ -120,11 +127,7 @@ public class FormRequestLambda {
                                 result.survey().title(),
                                 surveyId,
                                 memberId,
-                                result.survey().sections() != null
-                                    ? result.survey().sections().stream().mapToInt(s -> s.questions() != null
-                                        ? s.questions().size()
-                                        : 0).sum()
-                                    : 0,
+                                questionCount,
                                 result.unsupportedQuestions() != null ? result.unsupportedQuestions().stream()
                                     .map(q -> new SurveyConversionAlert.SurveyDetails.UnsupportedQuestion(q.order(), q.type(), q.reason()))
                                     .toList() : List.of()

--- a/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormRequestLambda.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormRequestLambda.java
@@ -65,7 +65,7 @@ public class FormRequestLambda {
             .retrieve()
             .bodyToMono(FormValidationAndStashResponse.class)
             .timeout(Duration.ofSeconds(FORM_CONVERSION_REQUEST_TIMEOUT))
-            .retryWhen(Retry.backoff(3, Duration.ofSeconds(3)))
+            .retryWhen(Retry.backoff(2, Duration.ofSeconds(3)))
             .onErrorMap(e -> {
                 log.error("[FormRequestLambda:validateAndStashFormRequest] 구글폼 링크 유효성 검사 실패 - URLs: {}, error: {}", payload.urls(), e.getMessage(), e);
                 throw new CustomException(SurveyErrorCode.FORM_VALIDATION_FAILED);

--- a/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormRequestLambda.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormRequestLambda.java
@@ -9,11 +9,15 @@ import OneQ.OnSurvey.domain.question.model.dto.QuestionUpsertDto;
 import OneQ.OnSurvey.domain.question.model.dto.SectionDto;
 import OneQ.OnSurvey.domain.question.service.QuestionCommand;
 import OneQ.OnSurvey.domain.survey.SurveyErrorCode;
+import OneQ.OnSurvey.domain.survey.entity.FormRequest;
 import OneQ.OnSurvey.domain.survey.model.formRequest.FormConversionPayload;
 import OneQ.OnSurvey.domain.survey.model.formRequest.FormConversionResponse;
+import OneQ.OnSurvey.domain.survey.model.formRequest.FormValidationAndStashResponse;
+import OneQ.OnSurvey.domain.survey.model.formRequest.FormValidationPayload;
 import OneQ.OnSurvey.domain.survey.model.formRequest.event.FormRequestConversionEvent;
 import OneQ.OnSurvey.domain.survey.model.request.SurveyFormCreateRequest;
 import OneQ.OnSurvey.domain.survey.model.response.SurveyFormResponse;
+import OneQ.OnSurvey.domain.survey.repository.formRequest.FormRequestRepository;
 import OneQ.OnSurvey.domain.survey.service.command.SurveyCommand;
 import OneQ.OnSurvey.global.common.exception.CustomException;
 import OneQ.OnSurvey.global.infra.discord.notifier.AlertNotifier;
@@ -38,6 +42,8 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
+import static OneQ.OnSurvey.domain.survey.SurveyErrorCode.FORM_REQUEST_NOT_FOUND;
+
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -46,7 +52,9 @@ public class FormRequestLambda {
     private static final long FORM_CONVERSION_REQUEST_TIMEOUT = 20L;
 
     @Value("${external.lambda.survey-conversion.url:}")
-    private String lambdaUrl;
+    private String conversionUrl;
+    @Value("${external.lambda.google-form-validation.url:}")
+    private String validationUrl;
 
     private final AlertNotifier alertNotifier;
     private final TransactionHandler transactionHandler;
@@ -54,9 +62,10 @@ public class FormRequestLambda {
     private final WebClient webClient;
 
     private final MemberFinder memberFinder;
-    private final FormUpdater formUpdater;
     private final SurveyCommand surveyCommand;
     private final QuestionCommand questionCommand;
+
+    private final FormRequestRepository formRequestRepository;
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
@@ -66,7 +75,7 @@ public class FormRequestLambda {
         FormConversionPayload payload = new FormConversionPayload(event.formUrls());
 
         FormConversionResponse response = webClient.post()
-            .uri(lambdaUrl)
+            .uri(conversionUrl)
             .contentType(MediaType.APPLICATION_JSON)
             .bodyValue(payload)
             .retrieve()
@@ -106,7 +115,9 @@ public class FormRequestLambda {
                     detailList.add(
                         transactionHandler.runInTransaction(() -> {
                             Long surveyId = createSurveyFromConversionResult(result, memberId);
-                            formUpdater.markAsRegistered(event.requestId(), surveyId);
+                            FormRequest request = formRequestRepository.findById(event.requestId())
+                                .orElseThrow(() -> new CustomException(FORM_REQUEST_NOT_FOUND));
+                            request.markAsRegistered(surveyId);
 
                             log.info("[FormRequestLambda] 구글폼 변환 성공 - requestId: {}, surveyId: {}", event.requestId(), surveyId);
                             if (result.unsupportedQuestions() != null && !result.unsupportedQuestions().isEmpty()) {
@@ -144,6 +155,30 @@ public class FormRequestLambda {
         alertNotifier.sendSurveyConversionAsync(
             SurveyConversionAlert.success(response.totalCount(), response.successCount(), detailList)
         );
+    }
+
+    public FormValidationAndStashResponse validateAndStashFormRequest(String formLink, String requesterEmail) {
+        FormValidationPayload payload = new FormValidationPayload(List.of(formLink), requesterEmail);
+
+        FormValidationAndStashResponse response = webClient.post()
+            .uri(validationUrl)
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(payload)
+            .retrieve()
+            .bodyToMono(FormValidationAndStashResponse.class)
+            .timeout(Duration.ofSeconds(FORM_CONVERSION_REQUEST_TIMEOUT))
+            .retryWhen(Retry.backoff(3, Duration.ofSeconds(3)))
+            .onErrorMap(e -> {
+                log.error("[FormRequestLambda:validateAndStashFormRequest] 구글폼 링크 유효성 검사 실패 - URLs: {}, error: {}", payload.urls(), e.getMessage(), e);
+                throw new CustomException(SurveyErrorCode.FORM_VALIDATION_FAILED);
+            })
+            .block();
+
+        if (response == null || response.successCount() == 0) {
+            log.warn("[FormRequestLambda:validateAndStashFormRequest] 구글폼 링크가 유효하지 않음 - URLs: {}", payload.urls());
+            throw new CustomException(SurveyErrorCode.FORM_INVALID);
+        }
+        return response;
     }
 
     private Long createSurveyFromConversionResult(FormConversionResponse.Result result, Long memberId) {

--- a/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormRequestLambda.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormRequestLambda.java
@@ -109,7 +109,6 @@ public class FormRequestLambda {
                             formUpdater.markAsRegistered(event.requestId(), surveyId);
 
                             log.info("[FormRequestLambda] 구글폼 변환 성공 - requestId: {}, surveyId: {}", event.requestId(), surveyId);
-
                             if (result.unsupportedQuestions() != null && !result.unsupportedQuestions().isEmpty()) {
                                 log.warn("[FormRequestLambda] 지원하지 않는 문항 존재 - requestId: {}, count: {}",
                                     event.requestId(), result.unsupportedQuestions().size());
@@ -158,8 +157,6 @@ public class FormRequestLambda {
         SurveyFormResponse surveyResponse = surveyCommand.upsertSurvey(memberId, null, surveyRequest);
         Long surveyId = surveyResponse.surveyId();
 
-        log.info("[FormRequestLambda] 설문 생성 완료 - surveyId: {}, title: {}", surveyId, survey.title());
-
         // 2. 섹션 생성
         if (survey.sections() != null && !survey.sections().isEmpty()) {
             List<SectionDto> sectionDtoList = survey.sections().stream()
@@ -173,7 +170,6 @@ public class FormRequestLambda {
                 .toList();
 
             questionCommand.upsertSections(surveyId, sectionDtoList);
-            log.info("[FormRequestLambda] 섹션 생성 완료 - surveyId: {}, sectionCount: {}", surveyId, sectionDtoList.size());
         }
 
         // 3. 문항 생성
@@ -186,8 +182,6 @@ public class FormRequestLambda {
                     for (FormConversionResponse.Question question : section.questions()) {
                         QuestionType questionType = mapQuestionType(question.type());
                         if (questionType == null) {
-                            log.warn("[FormRequestLambda] 지원하지 않는 문항 타입 - type: {}, title: {}",
-                                question.type(), question.title());
                             continue;
                         }
 
@@ -240,8 +234,6 @@ public class FormRequestLambda {
                 .build();
 
             QuestionUpsertDto savedQuestions = questionCommand.upsertQuestionList(questionUpsertDto);
-            log.info("[FormRequestLambda] 문항 생성 완료 - surveyId: {}, questionCount: {}",
-                surveyId, savedQuestions.getUpsertInfoList().size());
 
             // 4. Choice 문항의 옵션 저장
             List<OptionUpsertDto> optionUpsertDtoList = new ArrayList<>();
@@ -271,8 +263,6 @@ public class FormRequestLambda {
 
             if (!optionUpsertDtoList.isEmpty()) {
                 questionCommand.upsertChoiceOptionList(optionUpsertDtoList);
-                log.info("[FormRequestLambda] 옵션 생성 완료 - surveyId: {}, choiceQuestionCount: {}",
-                    surveyId, optionUpsertDtoList.size());
             }
         }
 

--- a/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormUpdater.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormUpdater.java
@@ -1,5 +1,5 @@
 package OneQ.OnSurvey.domain.survey.service.formRequest;
 
 public interface FormUpdater {
-    void markAsRegistered(Long requestId, Long surveyId);
+    void markAsRegistered(Long requestId, Long surveyId, Integer questionCount);
 }


### PR DESCRIPTION
### ✨ Related Issue
- [OMF-274 구글폼 변환성공 문항 개수 반환](https://onsurvey.atlassian.net/browse/OMF-274)
- [OMF-250](https://onsurvey.atlassian.net/browse/OMF-250)

---

### 📌 Task Details
- [x] 구글폼 변환 신청 플로우 반영
  - 구글폼 변환 결제 후 설문 등록, 변환, 발행 자동화
- [x] 구글폼 링크 유효성 검사 시, 변환 가능/불가능한 문항 개수와 불가능한 문항 정보 반환

---

### 💬 Review Requirements (Optional)



[OMF-250]: https://onsurvey.atlassian.net/browse/OMF-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 할인 코드 만료 기능 추가
  * 설문 제목 질문 유형 추가
  * 구글 폼 링크 유효성 검사 기능 추가
  * 구글 폼 발행 기능 추가

* **변경 사항**
  * 할인 코드 길이 제한 변경
  * 이미지 질문에서 필수 설정 옵션 제거

* **버그 수정**
  * 만료된 할인 코드 사용 시 오류 처리 개선
  * 구글 폼 변환 오류 처리 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->