### PR TITLE
♻️ OMF-281 surveyInfo에 상세 가격 request 삭제 및 response 기본 값 설정

### DIFF
--- a/src/main/java/OneQ/OnSurvey/domain/survey/model/request/SurveyFormRequest.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/model/request/SurveyFormRequest.java
@@ -16,23 +16,15 @@ public record SurveyFormRequest(
 
         @Schema(description = "성별", example = "ALL")
         Gender gender,
-        @Schema(description = "성별 가격", example = "100")
-        Integer genderPrice,
 
         @Schema(description = "연령대 목록", example = "[\"TEN\",\"TWENTY\",\"THIRTY\"]")
         List<AgeRange> ages,
-        @Schema(description = "연령대 가격", example = "100")
-        Integer agePrice,
 
         @Schema(description = "거주지", example = "SEOUL")
         Residence residence,
-        @Schema(description = "거주지 가격", example = "100")
-        Integer residencePrice,
 
         @Schema(description = "응답자 수", example = "50")
         Integer dueCount,
-        @Schema(description = "응답자 수 가격", example = "5000")
-        Integer dueCountPrice,
 
         @Schema(description = "총 코인", example = "10000")
         Integer totalCoin,

--- a/src/main/java/OneQ/OnSurvey/domain/survey/model/response/SurveyInfoResponse.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/model/response/SurveyInfoResponse.java
@@ -25,13 +25,13 @@ public record SurveyInfoResponse(
 
         return new SurveyInfoResponse(
                 info.getDueCount(),
-                info.getDueCountPrice(),
+                info.getDueCountPrice() != null ? info.getDueCountPrice() : 0,
                 info.getGender(),
-                info.getGenderPrice(),
+                info.getGenderPrice() != null ? info.getGenderPrice() : 0,
                 ages,
-                info.getAgePrice(),
+                info.getAgePrice() != null ? info.getAgePrice() : 0,
                 info.getResidence(),
-                info.getResidencePrice()
+                info.getResidencePrice() != null ? info.getResidencePrice() : 0
         );
     }
 }

--- a/src/main/java/OneQ/OnSurvey/domain/survey/service/command/SurveyCommandService.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/service/command/SurveyCommandService.java
@@ -147,10 +147,6 @@ public class SurveyCommandService implements SurveyCommand {
                 request.gender(),
                 ages,
                 request.residence(),
-                request.genderPrice(),
-                request.agePrice(),
-                request.residencePrice(),
-                request.dueCountPrice(),
                 resolvedPromotionAmount,
                 discountCodeId,
                 true
@@ -176,7 +172,6 @@ public class SurveyCommandService implements SurveyCommand {
                 Gender.ALL,
                 Set.of(AgeRange.ALL),
                 Residence.ALL,
-                0, 0, 0, 0,
                 0,
                 null,
                 false
@@ -308,10 +303,6 @@ public class SurveyCommandService implements SurveyCommand {
             Gender gender,
             Set<AgeRange> ages,
             Residence residence,
-            Integer genderPrice,
-            Integer agePrice,
-            Integer residencePrice,
-            Integer dueCountPrice,
             Integer promotionAmount,
             Long discountCodeId,
             boolean refundable
@@ -319,10 +310,10 @@ public class SurveyCommandService implements SurveyCommand {
         SurveyInfo info = surveyInfoRepository.findBySurveyId(surveyId)
                 .orElseGet(() -> SurveyInfo.createSurveyInfo(
                         surveyId, dueCount, gender, ages, residence,
-                        genderPrice, agePrice, residencePrice, dueCountPrice, promotionAmount, discountCodeId
+                        0, 0, 0, 0, promotionAmount, discountCodeId
                 ));
 
-        info.updateSurveyInfo(dueCount, gender, ages, residence, genderPrice, agePrice, residencePrice, dueCountPrice, promotionAmount, discountCodeId);
+        info.updateSurveyInfo(dueCount, gender, ages, residence, 0, 0, 0, 0, promotionAmount, discountCodeId);
 
         if (!refundable) info.markNonRefundable();
 


### PR DESCRIPTION
### ✨ Related Issue
- [OMF-281](https://onsurvey.atlassian.net/browse/OMF-281)
---

### 📌 Task Details
- [x] 설문 폼 완성시 상세 가격 필드 제거
- [x] 결제 조회시 기존에 있던 데이터나 bo 로직과 충돌을 피하기 위해 null일 때 0으로 response 나가도록 설정
  - 당장 삭제할 필요는 없어서 비활성화 느낌으로 수정했어요

---

### 💬 Review Requirements (Optional)
- 최대한 사이드 이펙트 없는 방향으로 수정했는데, agePrice 등 필드 자체를 삭제하는 방향으로 가게 된다면 bo나 설문 등록 관련 로직 더 자세히 검토하고 수정해볼게여


[OMF-281]: https://onsurvey.atlassian.net/browse/OMF-281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 설문조사 생성 요청에서 가격 관련 파라미터를 제거했습니다. 성별가, 연령대가, 거주지역가, 납기한 응답수가 등의 개별 가격 설정이 더 이상 지원되지 않습니다.
  * 모든 가격 값이 기본값으로 통일되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->