### PR TITLE
✨ OMF-296  설문 변환 실패 후, 운영팀에 도움 요청 알림 전송

### DIFF
--- a/src/main/java/OneQ/OnSurvey/domain/survey/controller/SurveyHelpRequestController.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/controller/SurveyHelpRequestController.java
@@ -1,0 +1,48 @@
+package OneQ.OnSurvey.domain.survey.controller;
+
+import OneQ.OnSurvey.global.auth.custom.CustomUserDetails;
+import OneQ.OnSurvey.global.common.response.SuccessResponse;
+import OneQ.OnSurvey.global.infra.discord.notifier.AlertNotifier;
+import OneQ.OnSurvey.global.infra.discord.notifier.dto.SurveyHelpRequestAlert;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/v1/surveys/help-requests")
+@RequiredArgsConstructor
+public class SurveyHelpRequestController {
+
+    private final AlertNotifier alertNotifier;
+
+    @PostMapping
+    @Operation(summary = "설문 반려 도움 요청", description = "설문이 반려된 경우 운영팀에 도움을 요청합니다.")
+    public SuccessResponse<Void> requestHelp(
+            @AuthenticationPrincipal CustomUserDetails principal,
+            @RequestBody @Valid HelpRequest request
+    ) {
+        alertNotifier.sendSurveyHelpRequestAsync(new SurveyHelpRequestAlert(
+                request.email(),
+                request.name(),
+                request.rejectionReasons(),
+                request.content()
+        ));
+        return SuccessResponse.ok(null);
+    }
+
+    public record HelpRequest(
+            @NotBlank String email,
+            @NotBlank String name,
+            @NotEmpty List<String> rejectionReasons,
+            @NotBlank String content
+    ) {}
+}

--- a/src/main/java/OneQ/OnSurvey/domain/survey/controller/SurveyHelpRequestController.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/controller/SurveyHelpRequestController.java
@@ -4,6 +4,7 @@ import OneQ.OnSurvey.global.auth.custom.CustomUserDetails;
 import OneQ.OnSurvey.global.common.response.SuccessResponse;
 import OneQ.OnSurvey.global.infra.discord.notifier.AlertNotifier;
 import OneQ.OnSurvey.global.infra.discord.notifier.dto.SurveyHelpRequestAlert;
+import OneQ.OnSurvey.global.infra.redis.RedisCacheAction;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.Duration;
 import java.util.List;
 
 @RestController
@@ -22,7 +24,10 @@ import java.util.List;
 @RequiredArgsConstructor
 public class SurveyHelpRequestController {
 
+    private static final Duration HELP_REQUEST_COOLDOWN = Duration.ofSeconds(30);
+
     private final AlertNotifier alertNotifier;
+    private final RedisCacheAction redisCache;
 
     @PostMapping
     @Operation(summary = "설문 반려 도움 요청", description = "설문이 반려된 경우 운영팀에 도움을 요청합니다.")
@@ -30,12 +35,16 @@ public class SurveyHelpRequestController {
             @AuthenticationPrincipal CustomUserDetails principal,
             @RequestBody @Valid HelpRequest request
     ) {
-        alertNotifier.sendSurveyHelpRequestAsync(new SurveyHelpRequestAlert(
-                request.email(),
-                request.name(),
-                request.rejectionReasons(),
-                request.content()
-        ));
+        String dedupKey = "help-request:discord:" + principal.getUserKey();
+        Boolean acquired = redisCache.setValueIfAbsent(dedupKey, "1", HELP_REQUEST_COOLDOWN);
+        if (Boolean.TRUE.equals(acquired)) {
+            alertNotifier.sendSurveyHelpRequestAsync(new SurveyHelpRequestAlert(
+                    request.email(),
+                    request.name(),
+                    request.rejectionReasons(),
+                    request.content()
+            ));
+        }
         return SuccessResponse.ok(null);
     }
 

--- a/src/main/java/OneQ/OnSurvey/global/infra/discord/DiscordAlarmAsyncFacade.java
+++ b/src/main/java/OneQ/OnSurvey/global/infra/discord/DiscordAlarmAsyncFacade.java
@@ -2,6 +2,7 @@ package OneQ.OnSurvey.global.infra.discord;
 
 import OneQ.OnSurvey.global.infra.discord.notifier.dto.PaymentCompletedAlert;
 import OneQ.OnSurvey.global.infra.discord.notifier.dto.SurveyConversionAlert;
+import OneQ.OnSurvey.global.infra.discord.notifier.dto.SurveyHelpRequestAlert;
 import OneQ.OnSurvey.global.infra.discord.notifier.dto.SurveySubmittedAlert;
 import OneQ.OnSurvey.global.infra.discord.notifier.dto.TossAccessTokenAlert;
 import OneQ.OnSurvey.global.infra.discord.notifier.dto.PushAlimAlert;
@@ -42,5 +43,10 @@ public class DiscordAlarmAsyncFacade {
     @Async("discordAlarmExecutor")
     public void sendPushAlimAsync(PushAlimAlert alert) {
         service.sendPushAlimAsync(alert);
+    }
+
+    @Async("discordAlarmExecutor")
+    public void sendSurveyHelpRequestAsync(SurveyHelpRequestAlert alert) {
+        service.sendSurveyHelpRequestAlert(alert);
     }
 }

--- a/src/main/java/OneQ/OnSurvey/global/infra/discord/DiscordAlarmService.java
+++ b/src/main/java/OneQ/OnSurvey/global/infra/discord/DiscordAlarmService.java
@@ -4,6 +4,7 @@ import OneQ.OnSurvey.global.common.util.JwtDecodeUtils;
 import OneQ.OnSurvey.global.infra.discord.client.DiscordWebhookClient;
 import OneQ.OnSurvey.global.infra.discord.notifier.dto.PaymentCompletedAlert;
 import OneQ.OnSurvey.global.infra.discord.notifier.dto.SurveyConversionAlert;
+import OneQ.OnSurvey.global.infra.discord.notifier.dto.SurveyHelpRequestAlert;
 import OneQ.OnSurvey.global.infra.discord.notifier.dto.SurveySubmittedAlert;
 import OneQ.OnSurvey.global.infra.discord.notifier.dto.TossAccessTokenAlert;
 import OneQ.OnSurvey.global.infra.discord.notifier.dto.PushAlimAlert;
@@ -47,6 +48,9 @@ public class DiscordAlarmService {
   
     @Value("${discord.push-alim-alert-url:}")
     private String pushAlimWebhookUrl;
+
+    @Value("${discord.survey-help-request-url:}")
+    private String surveyHelpRequestWebhookUrl;
 
     public void sendErrorAlert(Throwable e, String method, String path, String query) {
         if (!enabled || errorWebhookUrl == null || errorWebhookUrl.isBlank()) return;
@@ -192,6 +196,30 @@ public class DiscordAlarmService {
                 "• 실패 상세: `" + safe(alert.errorReason()) + "`\n";
         }
         post(url, title, description);
+    }
+
+    public void sendSurveyHelpRequestAlert(SurveyHelpRequestAlert alert) {
+        if (!enabled) return;
+
+        String url = (surveyHelpRequestWebhookUrl != null && !surveyHelpRequestWebhookUrl.isBlank())
+                ? surveyHelpRequestWebhookUrl
+                : errorWebhookUrl;
+        if (url == null || url.isBlank()) return;
+
+        StringBuilder desc = new StringBuilder();
+        desc.append("• 이름: `").append(safe(alert.name())).append("`\n")
+            .append("• 이메일: `").append(safe(alert.email())).append("`\n")
+            .append("• 반려 사유:\n");
+        for (String reason : alert.rejectionReasons()) {
+            desc.append("- ").append(safe(reason)).append("\n");
+        }
+        desc.append("• 문의 내용:\n```\n").append(safe(alert.content())).append("\n```");
+
+        String descStr = desc.toString();
+        if (descStr.length() > MAX_EMBED_DESC) {
+            descStr = descStr.substring(0, MAX_EMBED_DESC - TRUNC_SUFFIX.length()) + TRUNC_SUFFIX;
+        }
+        post(url, "🆘 설문 변환 실패. 도움 요청", descStr);
     }
 
     private String maskKey(String key) {

--- a/src/main/java/OneQ/OnSurvey/global/infra/discord/DiscordAlarmService.java
+++ b/src/main/java/OneQ/OnSurvey/global/infra/discord/DiscordAlarmService.java
@@ -2,12 +2,7 @@ package OneQ.OnSurvey.global.infra.discord;
 
 import OneQ.OnSurvey.global.common.util.JwtDecodeUtils;
 import OneQ.OnSurvey.global.infra.discord.client.DiscordWebhookClient;
-import OneQ.OnSurvey.global.infra.discord.notifier.dto.PaymentCompletedAlert;
-import OneQ.OnSurvey.global.infra.discord.notifier.dto.SurveyConversionAlert;
-import OneQ.OnSurvey.global.infra.discord.notifier.dto.SurveyHelpRequestAlert;
-import OneQ.OnSurvey.global.infra.discord.notifier.dto.SurveySubmittedAlert;
-import OneQ.OnSurvey.global.infra.discord.notifier.dto.TossAccessTokenAlert;
-import OneQ.OnSurvey.global.infra.discord.notifier.dto.PushAlimAlert;
+import OneQ.OnSurvey.global.infra.discord.notifier.dto.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -207,13 +202,13 @@ public class DiscordAlarmService {
         if (url == null || url.isBlank()) return;
 
         StringBuilder desc = new StringBuilder();
-        desc.append("• 이름: `").append(safe(alert.name())).append("`\n")
-            .append("• 이메일: `").append(safe(alert.email())).append("`\n")
+        desc.append("• 이름: `").append(sanitizeForDiscord(alert.name())).append("`\n")
+            .append("• 이메일: `").append(sanitizeForDiscord(alert.email())).append("`\n")
             .append("• 반려 사유:\n");
         for (String reason : alert.rejectionReasons()) {
-            desc.append("- ").append(safe(reason)).append("\n");
+            desc.append("- ").append(sanitizeForDiscord(reason)).append("\n");
         }
-        desc.append("• 문의 내용:\n```\n").append(safe(alert.content())).append("\n```");
+        desc.append("• 문의 내용:\n```\n").append(sanitizeForDiscord(alert.content())).append("\n```");
 
         String descStr = desc.toString();
         if (descStr.length() > MAX_EMBED_DESC) {
@@ -299,5 +294,14 @@ public class DiscordAlarmService {
     }
 
     private String safe(String s) { return s == null ? "" : s; }
+
+    private String sanitizeForDiscord(String s) {
+        if (s == null) return "";
+        return s
+                .replace("\\", "\\\\")
+                .replace("@", "@\u200B")
+                .replace("`", "`\u200B")
+                .replaceAll("<(@[!&]?|#)\\d+>", "[mention]");
+    }
     private String nullToEmpty(String s) { return s == null ? "" : s; }
 }

--- a/src/main/java/OneQ/OnSurvey/global/infra/discord/notifier/AlertNotifier.java
+++ b/src/main/java/OneQ/OnSurvey/global/infra/discord/notifier/AlertNotifier.java
@@ -2,6 +2,7 @@ package OneQ.OnSurvey.global.infra.discord.notifier;
 
 import OneQ.OnSurvey.global.infra.discord.notifier.dto.PaymentCompletedAlert;
 import OneQ.OnSurvey.global.infra.discord.notifier.dto.SurveyConversionAlert;
+import OneQ.OnSurvey.global.infra.discord.notifier.dto.SurveyHelpRequestAlert;
 import OneQ.OnSurvey.global.infra.discord.notifier.dto.SurveySubmittedAlert;
 import OneQ.OnSurvey.global.infra.discord.notifier.dto.TossAccessTokenAlert;
 import OneQ.OnSurvey.global.infra.discord.notifier.dto.PushAlimAlert;
@@ -13,4 +14,5 @@ public interface AlertNotifier {
     void sendTossAccessTokenAsync(TossAccessTokenAlert alert);
     void sendSurveyConversionAsync(SurveyConversionAlert alert);
     void sendPushAlimAsync(PushAlimAlert alert);
+    void sendSurveyHelpRequestAsync(SurveyHelpRequestAlert alert);
 }

--- a/src/main/java/OneQ/OnSurvey/global/infra/discord/notifier/DiscordAlertNotifier.java
+++ b/src/main/java/OneQ/OnSurvey/global/infra/discord/notifier/DiscordAlertNotifier.java
@@ -3,6 +3,7 @@ package OneQ.OnSurvey.global.infra.discord.notifier;
 import OneQ.OnSurvey.global.infra.discord.DiscordAlarmAsyncFacade;
 import OneQ.OnSurvey.global.infra.discord.notifier.dto.PaymentCompletedAlert;
 import OneQ.OnSurvey.global.infra.discord.notifier.dto.SurveyConversionAlert;
+import OneQ.OnSurvey.global.infra.discord.notifier.dto.SurveyHelpRequestAlert;
 import OneQ.OnSurvey.global.infra.discord.notifier.dto.SurveySubmittedAlert;
 import OneQ.OnSurvey.global.infra.discord.notifier.dto.TossAccessTokenAlert;
 import OneQ.OnSurvey.global.infra.discord.notifier.dto.PushAlimAlert;
@@ -45,5 +46,10 @@ public class DiscordAlertNotifier implements AlertNotifier {
     @Override
     public void sendPushAlimAsync(PushAlimAlert alert) {
         discord.sendPushAlimAsync(alert);
+    }
+
+    @Override
+    public void sendSurveyHelpRequestAsync(SurveyHelpRequestAlert alert) {
+        discord.sendSurveyHelpRequestAsync(alert);
     }
 }

--- a/src/main/java/OneQ/OnSurvey/global/infra/discord/notifier/NoOpAlertNotifier.java
+++ b/src/main/java/OneQ/OnSurvey/global/infra/discord/notifier/NoOpAlertNotifier.java
@@ -3,6 +3,7 @@ package OneQ.OnSurvey.global.infra.discord.notifier;
 import OneQ.OnSurvey.global.infra.discord.notifier.dto.PaymentCompletedAlert;
 import OneQ.OnSurvey.global.infra.discord.notifier.dto.PushAlimAlert;
 import OneQ.OnSurvey.global.infra.discord.notifier.dto.SurveyConversionAlert;
+import OneQ.OnSurvey.global.infra.discord.notifier.dto.SurveyHelpRequestAlert;
 import OneQ.OnSurvey.global.infra.discord.notifier.dto.SurveySubmittedAlert;
 import OneQ.OnSurvey.global.infra.discord.notifier.dto.TossAccessTokenAlert;
 import org.springframework.context.annotation.Profile;
@@ -29,4 +30,7 @@ public class NoOpAlertNotifier implements AlertNotifier {
   
     @Override
     public void sendPushAlimAsync(PushAlimAlert alert) {}
+
+    @Override
+    public void sendSurveyHelpRequestAsync(SurveyHelpRequestAlert alert) {}
 }

--- a/src/main/java/OneQ/OnSurvey/global/infra/discord/notifier/dto/SurveyHelpRequestAlert.java
+++ b/src/main/java/OneQ/OnSurvey/global/infra/discord/notifier/dto/SurveyHelpRequestAlert.java
@@ -1,0 +1,10 @@
+package OneQ.OnSurvey.global.infra.discord.notifier.dto;
+
+import java.util.List;
+
+public record SurveyHelpRequestAlert(
+        String email,
+        String name,
+        List<String> rejectionReasons,
+        String content
+) {}


### PR DESCRIPTION
### ✨ Related Issue
- [OMF-296](https://onsurvey.atlassian.net/browse/OMF-296)

---

### 📌 Task Details
- [x] 설문 변환 실패 후, 도움 요청(DB 저장 없이 디코 알림) API 추가

---

### 💬 Review Requirements (Optional)
- 폴더 구조도 애매하고 추가된 컨트롤러에 의존적이라 dto 별도 클래스로 분리 안 했습니다


[OMF-296]: https://onsurvey.atlassian.net/browse/OMF-296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 설문 도움 요청 기능 추가: 사용자가 이메일, 이름, 거절 사유, 내용을 포함하여 도움을 요청할 수 있습니다.
  * 요청 유효성 검증 강화: 필수 필드에 대한 입력값 검증이 적용됩니다.
  * 비동기 알림 시스템: 제출된 도움 요청이 실시간으로 처리 및 전달됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->