### PR TITLE
✨ OMF-297 폼링크 유효성 검사 중복요청 방지 및 이메일 전송 일일 한도 설정

### DIFF
--- a/src/main/java/OneQ/OnSurvey/domain/member/repository/MemberRepository.java
+++ b/src/main/java/OneQ/OnSurvey/domain/member/repository/MemberRepository.java
@@ -16,4 +16,5 @@ public interface MemberRepository {
 
     Long validateAdminRoleAndGetMemberIdByUserKey(Long userKey);
     List<Member> searchMembers(String email, String phoneNumber, Long memberId, String name);
+    String getUsernameByUserKey(Long userKey);
 }

--- a/src/main/java/OneQ/OnSurvey/domain/member/repository/MemberRepositoryImpl.java
+++ b/src/main/java/OneQ/OnSurvey/domain/member/repository/MemberRepositoryImpl.java
@@ -116,4 +116,12 @@ public class MemberRepositoryImpl implements MemberRepository {
             .limit(100)
             .fetch();
     }
+
+    @Override
+    public String getUsernameByUserKey(Long userKey) {
+        return jpaQueryFactory.select(member.name)
+            .from(member)
+            .where(member.userKey.eq(userKey))
+            .fetchOne();
+    }
 }

--- a/src/main/java/OneQ/OnSurvey/domain/member/service/MemberFinder.java
+++ b/src/main/java/OneQ/OnSurvey/domain/member/service/MemberFinder.java
@@ -12,4 +12,5 @@ public interface MemberFinder {
 
     Long validateAdminRoleAndGetMemberIdByUserKey(Long userKey);
     List<MemberSearchResult> searchMembers(String email, String phoneNumber, Long memberId, String name);
+    String getUsernameByUserKey(Long userKey);
 }

--- a/src/main/java/OneQ/OnSurvey/domain/member/service/MemberQueryService.java
+++ b/src/main/java/OneQ/OnSurvey/domain/member/service/MemberQueryService.java
@@ -47,4 +47,9 @@ public class MemberQueryService implements MemberFinder {
         List<Member> members = memberRepository.searchMembers(email, phoneNumber, memberId, name);
         return MemberSearchResult.from(members);
     }
+
+    @Override
+    public String getUsernameByUserKey(Long userKey) {
+        return memberRepository.getUsernameByUserKey(userKey);
+    }
 }

--- a/src/main/java/OneQ/OnSurvey/domain/survey/SurveyErrorCode.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/SurveyErrorCode.java
@@ -34,6 +34,8 @@ public enum SurveyErrorCode implements ApiErrorCode {
     FORM_REQUEST_NOT_FOUND("FORM_REQUEST_404", "구글 폼 신청을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     FORM_CONVERSION_FAILED("FORM_REQUEST_001", "구글 폼 변환에 실패했습니다.", HttpStatus.BAD_REQUEST),
     FORM_VALIDATION_FAILED("FORM_REQUEST_002", "구글 폼 링크 유효성 검사에 실패했습니다.", HttpStatus.BAD_REQUEST),
+    FORM_VALIDATION_PROCEED("FORM_REQUEST_003", "구글 폼 링크 유효성 검사를 진행 중입니다.", HttpStatus.CONFLICT),
+    FORM_VALIDATION_EMAIL_TOO_MANY_REQUEST("FORM_REQUEST_429", "구글 폼 링크 유효성 검사 일일 이메일 한도를 초과했습니다.", HttpStatus.TOO_MANY_REQUESTS),
     FORM_REQUEST_NOT_YET_REGISTERED("FORM_REQUEST_409", "아직 설문 변환이 완료되지 않았습니다.", HttpStatus.CONFLICT),
     FORM_REQUEST_MEMBER_NOT_FOUND("FORM_REQUEST_MEMBER_404", "폼 신청자에 해당하는 회원을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
 

--- a/src/main/java/OneQ/OnSurvey/domain/survey/SurveyErrorCode.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/SurveyErrorCode.java
@@ -35,7 +35,7 @@ public enum SurveyErrorCode implements ApiErrorCode {
     FORM_CONVERSION_FAILED("FORM_REQUEST_001", "구글 폼 변환에 실패했습니다.", HttpStatus.BAD_REQUEST),
     FORM_VALIDATION_FAILED("FORM_REQUEST_002", "구글 폼 링크 유효성 검사에 실패했습니다.", HttpStatus.BAD_REQUEST),
     FORM_VALIDATION_PROCEED("FORM_REQUEST_003", "구글 폼 링크 유효성 검사를 진행 중입니다.", HttpStatus.CONFLICT),
-    FORM_VALIDATION_EMAIL_TOO_MANY_REQUEST("FORM_REQUEST_004", "구글 폼 링크 유효성 검사 이메일 시간 당 한도를 초과했습니다. ", HttpStatus.TOO_MANY_REQUESTS),
+    FORM_VALIDATION_EMAIL_TOO_MANY_REQUEST("FORM_REQUEST_004", "구글 폼 링크 유효성 검사 이메일 시간 당 한도를 초과했습니다. 잠시 후 시도해주세요.", HttpStatus.TOO_MANY_REQUESTS),
     FORM_VALIDATION_BAD_GATEWAY("FORM_REQUEST_005", "구글 폼 링크 유효성 검사가 정상적으로 수행되지 않았습니다.", HttpStatus.BAD_GATEWAY),
     FORM_REQUEST_NOT_YET_REGISTERED("FORM_REQUEST_409", "아직 설문 변환이 완료되지 않았습니다.", HttpStatus.CONFLICT),
     FORM_REQUEST_MEMBER_NOT_FOUND("FORM_REQUEST_MEMBER_404", "폼 신청자에 해당하는 회원을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);

--- a/src/main/java/OneQ/OnSurvey/domain/survey/SurveyErrorCode.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/SurveyErrorCode.java
@@ -35,7 +35,8 @@ public enum SurveyErrorCode implements ApiErrorCode {
     FORM_CONVERSION_FAILED("FORM_REQUEST_001", "구글 폼 변환에 실패했습니다.", HttpStatus.BAD_REQUEST),
     FORM_VALIDATION_FAILED("FORM_REQUEST_002", "구글 폼 링크 유효성 검사에 실패했습니다.", HttpStatus.BAD_REQUEST),
     FORM_VALIDATION_PROCEED("FORM_REQUEST_003", "구글 폼 링크 유효성 검사를 진행 중입니다.", HttpStatus.CONFLICT),
-    FORM_VALIDATION_EMAIL_TOO_MANY_REQUEST("FORM_REQUEST_429", "구글 폼 링크 유효성 검사 일일 이메일 한도를 초과했습니다.", HttpStatus.TOO_MANY_REQUESTS),
+    FORM_VALIDATION_EMAIL_TOO_MANY_REQUEST("FORM_REQUEST_004", "구글 폼 링크 유효성 검사 일일 이메일 한도를 초과했습니다.", HttpStatus.TOO_MANY_REQUESTS),
+    FORM_VALIDATION_BAD_GATEWAY("FORM_REQUEST_005", "구글 폼 링크 유효성 검사가 정상적으로 수행되지 않았습니다.", HttpStatus.BAD_GATEWAY),
     FORM_REQUEST_NOT_YET_REGISTERED("FORM_REQUEST_409", "아직 설문 변환이 완료되지 않았습니다.", HttpStatus.CONFLICT),
     FORM_REQUEST_MEMBER_NOT_FOUND("FORM_REQUEST_MEMBER_404", "폼 신청자에 해당하는 회원을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
 

--- a/src/main/java/OneQ/OnSurvey/domain/survey/SurveyErrorCode.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/SurveyErrorCode.java
@@ -35,7 +35,7 @@ public enum SurveyErrorCode implements ApiErrorCode {
     FORM_CONVERSION_FAILED("FORM_REQUEST_001", "구글 폼 변환에 실패했습니다.", HttpStatus.BAD_REQUEST),
     FORM_VALIDATION_FAILED("FORM_REQUEST_002", "구글 폼 링크 유효성 검사에 실패했습니다.", HttpStatus.BAD_REQUEST),
     FORM_VALIDATION_PROCEED("FORM_REQUEST_003", "구글 폼 링크 유효성 검사를 진행 중입니다.", HttpStatus.CONFLICT),
-    FORM_VALIDATION_EMAIL_TOO_MANY_REQUEST("FORM_REQUEST_004", "구글 폼 링크 유효성 검사 일일 이메일 한도를 초과했습니다.", HttpStatus.TOO_MANY_REQUESTS),
+    FORM_VALIDATION_EMAIL_TOO_MANY_REQUEST("FORM_REQUEST_004", "구글 폼 링크 유효성 검사 이메일 시간 당 한도를 초과했습니다. ", HttpStatus.TOO_MANY_REQUESTS),
     FORM_VALIDATION_BAD_GATEWAY("FORM_REQUEST_005", "구글 폼 링크 유효성 검사가 정상적으로 수행되지 않았습니다.", HttpStatus.BAD_GATEWAY),
     FORM_REQUEST_NOT_YET_REGISTERED("FORM_REQUEST_409", "아직 설문 변환이 완료되지 않았습니다.", HttpStatus.CONFLICT),
     FORM_REQUEST_MEMBER_NOT_FOUND("FORM_REQUEST_MEMBER_404", "폼 신청자에 해당하는 회원을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);

--- a/src/main/java/OneQ/OnSurvey/domain/survey/controller/FormRequestController.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/controller/FormRequestController.java
@@ -1,5 +1,6 @@
 package OneQ.OnSurvey.domain.survey.controller;
 
+import OneQ.OnSurvey.domain.survey.controller.swagger.FormRequestControllerDoc;
 import OneQ.OnSurvey.domain.survey.model.formRequest.FormValidationEmailQuotaResponse;
 import OneQ.OnSurvey.domain.survey.model.formRequest.FormValidationResponse;
 import OneQ.OnSurvey.domain.survey.model.formRequest.FormListResponse;
@@ -29,7 +30,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/v1/form-requests")
-public class FormRequestController {
+public class FormRequestController implements FormRequestControllerDoc {
 
     private final FormCreator formCreator;
     private final FormFinder formFinder;

--- a/src/main/java/OneQ/OnSurvey/domain/survey/controller/FormRequestController.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/controller/FormRequestController.java
@@ -1,5 +1,6 @@
 package OneQ.OnSurvey.domain.survey.controller;
 
+import OneQ.OnSurvey.domain.survey.model.formRequest.FormValidationEmailQuotaResponse;
 import OneQ.OnSurvey.domain.survey.model.formRequest.FormValidationResponse;
 import OneQ.OnSurvey.domain.survey.model.formRequest.FormListResponse;
 import OneQ.OnSurvey.domain.survey.model.formRequest.FormValidationRequestDto;
@@ -81,12 +82,21 @@ public class FormRequestController {
     @PostMapping("/validation")
     @Operation(summary = "폼 링크 유효성 검사 및 미리보기 반환", description = "구글 폼 편집 URL 유효성 검사를 진행하여 변환 가능한 문항 수, 변환 불가능 사유, 미리보기 데이터 등을 반환합니다.")
     public SuccessResponse<FormValidationResponse> getConvertableCounts(
-        @RequestBody @Valid FormValidationRequestDto request
+        @RequestBody @Valid FormValidationRequestDto request,
+        @AuthenticationPrincipal Authenticatable principal
     ) {
-        log.info("[FormRequest] 폼 링크 유효성 검사 - URL: {}", request.formLink());
+        log.info("[FormRequest] 폼 링크 유효성 검사 - URL: {}, 이메일수신: {}", request.formLink(), request.isEmailRequired());
 
-        FormValidationResponse response = formCreator.validationFormRequestLink(request);
+        FormValidationResponse response = formCreator.validationFormRequestLink(principal.getUserKey(), request);
         return SuccessResponse.ok(response);
+    }
+
+    @GetMapping("/email-quota")
+    @Operation(summary = "폼 링크 유효성 검사 결과 이메일 수신 일일 한도 조회", description = "사용자 별 링크 유효성 검사 결과에 대한 이메일 수신 일일 한도 잔량 조회을 조회합니다.")
+    public SuccessResponse<FormValidationEmailQuotaResponse> getEmailQuota(
+        @AuthenticationPrincipal Authenticatable principal
+    ) {
+        return SuccessResponse.ok(formFinder.getEmailQuota(principal.getUserKey()));
     }
 
     @PatchMapping("/{requestId}/publish")

--- a/src/main/java/OneQ/OnSurvey/domain/survey/controller/FormRequestController.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/controller/FormRequestController.java
@@ -86,7 +86,7 @@ public class FormRequestController implements FormRequestControllerDoc {
         @RequestBody @Valid FormValidationRequestDto request,
         @AuthenticationPrincipal Authenticatable principal
     ) {
-        log.info("[FormRequest] 폼 링크 유효성 검사 - URL: {}, 이메일수신: {}", request.formLink(), request.isEmailRequired());
+        log.info("[FormRequest] 폼 링크 유효성 검사 - URL: {}", request.formLink());
 
         FormValidationResponse response = formCreator.validationFormRequestLink(principal.getUserKey(), request);
         return SuccessResponse.ok(response);

--- a/src/main/java/OneQ/OnSurvey/domain/survey/controller/swagger/FormControllerDoc.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/controller/swagger/FormControllerDoc.java
@@ -53,7 +53,7 @@ public interface FormControllerDoc {
                                    "questionType": "LONG",
                                    "title": "string",
                                    "questionOrder": 2,
-                                   "section": 1,
+                                   "section": 1
                                 }
                             ]
                         }

--- a/src/main/java/OneQ/OnSurvey/domain/survey/controller/swagger/FormRequestControllerDoc.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/controller/swagger/FormRequestControllerDoc.java
@@ -31,12 +31,12 @@ public interface FormRequestControllerDoc {
                 }
             )
         ),
-        @ApiResponse(responseCode = "429", description = "이메일 일일 한도 초과",
+        @ApiResponse(responseCode = "429", description = "이메일 시간 당 한도 초과",
             content = @Content(
                 mediaType = "application/json",
                 schema = @Schema(implementation = ErrorResponse.class),
                 examples = {
-                    @ExampleObject(name = "폼 변환 이메일 일일 한도 초과", value = "{ \"code\": \"FORM_REQUEST_004\", \"message\": \"구글 폼 링크 유효성 검사 일일 이메일 한도를 초과했습니다.\" }")
+                    @ExampleObject(name = "폼 변환 이메일 시간 당 한도 초과", value = "{ \"code\": \"FORM_REQUEST_004\", \"message\": \"구글 폼 링크 유효성 검사 이메일 시간 당 한도를 초과했습니다. 잠시 후 시도해주세요.\" }")
                 }
             )
         ),

--- a/src/main/java/OneQ/OnSurvey/domain/survey/controller/swagger/FormRequestControllerDoc.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/controller/swagger/FormRequestControllerDoc.java
@@ -1,0 +1,57 @@
+package OneQ.OnSurvey.domain.survey.controller.swagger;
+
+import OneQ.OnSurvey.domain.survey.model.formRequest.FormValidationRequestDto;
+import OneQ.OnSurvey.domain.survey.model.formRequest.FormValidationResponse;
+import OneQ.OnSurvey.global.auth.custom.Authenticatable;
+import OneQ.OnSurvey.global.common.response.ErrorResponse;
+import OneQ.OnSurvey.global.common.response.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+public interface FormRequestControllerDoc {
+
+    @PostMapping("/validation")
+    @Operation(summary = "폼 링크 유효성 검사 및 미리보기 반환", description = "구글 폼 편집 URL 유효성 검사를 진행하여 변환 가능한 문항 수, 변환 불가능 사유, 미리보기 데이터 등을 반환합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "성공"),
+        @ApiResponse(responseCode = "409", description = "유효성 검사 진행 중",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = {
+                    @ExampleObject(name = "폼 변환 중복요청", value = "{ \"code\": \"FORM_REQUEST_003\", \"message\": \"구글 폼 링크 유효성 검사를 진행 중입니다.\" }")
+                }
+            )
+        ),
+        @ApiResponse(responseCode = "429", description = "이메일 일일 한도 초과",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = {
+                    @ExampleObject(name = "폼 변환 이메일 일일 한도 초과", value = "{ \"code\": \"FORM_REQUEST_004\", \"message\": \"구글 폼 링크 유효성 검사 일일 이메일 한도를 초과했습니다.\" }")
+                }
+            )
+        ),
+        @ApiResponse(responseCode = "502", description = "유효성 검사 실패",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = {
+                    @ExampleObject(name = "폼 링크 유효성 검사 실패", value = "{ \"code\": \"FORM_REQUEST_005\", \"message\": \"구글 폼 링크 유효성 검사가 정상적으로 수행되지 않았습니다.\" }")
+                }
+            )
+        ),
+    })
+    SuccessResponse<FormValidationResponse> getConvertableCounts(
+        @RequestBody @Valid FormValidationRequestDto request,
+        @AuthenticationPrincipal Authenticatable principal
+    );
+}

--- a/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/FormValidationEmailQuotaResponse.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/FormValidationEmailQuotaResponse.java
@@ -1,0 +1,6 @@
+package OneQ.OnSurvey.domain.survey.model.formRequest;
+
+public record FormValidationEmailQuotaResponse(
+    int quota
+) {
+}

--- a/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/FormValidationPayload.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/FormValidationPayload.java
@@ -5,6 +5,5 @@ import java.util.List;
 public record FormValidationPayload(
     List<String> urls,
     String requesterEmail,
-    Boolean isEmailRequired,
     String username
 ) { }

--- a/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/FormValidationPayload.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/FormValidationPayload.java
@@ -4,5 +4,6 @@ import java.util.List;
 
 public record FormValidationPayload(
     List<String> urls,
-    String requesterEmail
+    String requesterEmail,
+    Boolean isEmailRequired
 ) { }

--- a/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/FormValidationPayload.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/FormValidationPayload.java
@@ -5,5 +5,6 @@ import java.util.List;
 public record FormValidationPayload(
     List<String> urls,
     String requesterEmail,
-    Boolean isEmailRequired
+    Boolean isEmailRequired,
+    String username
 ) { }

--- a/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/FormValidationPostResponse.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/FormValidationPostResponse.java
@@ -8,7 +8,7 @@ import java.util.List;
 public record FormValidationPostResponse(
     int totalUrls,
     int successCount,
-    boolean isEmailSent,
+    int emailSent,
     List<Result> results
 ) {
 

--- a/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/FormValidationPostResponse.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/FormValidationPostResponse.java
@@ -32,7 +32,7 @@ public record FormValidationPostResponse(
     public record Count(
         int total,
         int convertible,
-        int unconvertible
+        int inconvertible
     ) { }
 
     public record Inconvertible(

--- a/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/FormValidationPostResponse.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/FormValidationPostResponse.java
@@ -8,6 +8,7 @@ import java.util.List;
 public record FormValidationPostResponse(
     int totalUrls,
     int successCount,
+    boolean isEmailSent,
     List<Result> results
 ) {
 

--- a/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/FormValidationRequestDto.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/FormValidationRequestDto.java
@@ -3,10 +3,15 @@ package OneQ.OnSurvey.domain.survey.model.formRequest;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import org.hibernate.validator.constraints.URL;
 
 public record FormValidationRequestDto(
     @Schema(description = "폼 편집 링크", example = "https://docs.google.com/forms/d/1FAIpQLSfD.../edit")
+    @Pattern(
+        regexp = "^https://docs\\.google\\.com/forms/d/[a-zA-Z0-9_-]+/(edit)(\\?.*)?$",
+        message = "유효한 구글 폼 주소가 아닙니다. (.../edit 형태여야 합니다.)"
+    )
     @URL @NotBlank
     String formLink,
 

--- a/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/FormValidationRequestDto.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/FormValidationRequestDto.java
@@ -12,6 +12,9 @@ public record FormValidationRequestDto(
 
     @Schema(description = "신청자 이메일", example = "test@gmail.com")
     @Email @NotBlank
-    String requesterEmail
+    String requesterEmail,
+
+    @Schema(description = "유효성 검사 결과 이메일 수신 요청 여부")
+    Boolean isEmailRequired
 ) {
 }

--- a/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/FormValidationRequestDto.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/FormValidationRequestDto.java
@@ -17,9 +17,6 @@ public record FormValidationRequestDto(
 
     @Schema(description = "신청자 이메일", example = "test@gmail.com")
     @Email @NotBlank
-    String requesterEmail,
-
-    @Schema(description = "유효성 검사 결과 이메일 수신 요청 여부")
-    Boolean isEmailRequired
+    String requesterEmail
 ) {
 }

--- a/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/FormValidationResponse.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/FormValidationResponse.java
@@ -94,7 +94,8 @@ public record FormValidationResponse(
             ]
             """
     )
-    List<Result> results
+    List<Result> results,
+    boolean isEmailSent
 ) {
 
     public record Result(

--- a/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/FormValidationResponse.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/FormValidationResponse.java
@@ -83,7 +83,7 @@ public record FormValidationResponse(
                     ]
                 }, {
                     "url": "https://docs.google.com/forms/d/e/1Eq41ykgka_.../viewform",
-                    "message": "유효하지 않은 구글폼 Edit 링크입니다."
+                    "message": "설문 편집 권한이 부여되지 않았습니다."
                 }, {
                     "url": "https://docs.google.com/forms/d/1Eq4gka_.../edit",
                     "message": "설문이 게시되지 않았습니다."
@@ -95,7 +95,7 @@ public record FormValidationResponse(
             """
     )
     List<Result> results,
-    boolean isEmailSent
+    int emailSent
 ) {
 
     public record Result(

--- a/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormCommandService.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormCommandService.java
@@ -16,6 +16,7 @@ import OneQ.OnSurvey.domain.survey.repository.formRequest.FormRequestRepository;
 import OneQ.OnSurvey.domain.survey.service.command.SurveyCommand;
 import OneQ.OnSurvey.domain.survey.service.query.SurveyQueryService;
 import OneQ.OnSurvey.global.common.exception.CustomException;
+import OneQ.OnSurvey.global.common.exception.ErrorCode;
 import OneQ.OnSurvey.global.infra.redis.RedisCacheAction;
 import OneQ.OnSurvey.global.infra.redis.RedisLockAction;
 import lombok.RequiredArgsConstructor;
@@ -136,7 +137,7 @@ public class FormCommandService implements FormCreator, FormUpdater, FormPublish
 
                     if (response == null) {
                         log.warn("[FORM:COMMAND:validationFormRequestLink] 구글폼 링크 유효성 검사 실패 - URL: {}", dto.formLink());
-                        throw new CustomException(SurveyErrorCode.FORM_VALIDATION_FAILED);
+                        throw new CustomException(SurveyErrorCode.FORM_VALIDATION_BAD_GATEWAY);
                     }
 
                     if (response.isEmailSent()) {
@@ -161,7 +162,7 @@ public class FormCommandService implements FormCreator, FormUpdater, FormPublish
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             log.warn("[FORM:COMMAND] 구글폼 링크 유효성 검사 락 획득 중 에러 발생 - userKey: {}", userKey);
-            throw new CustomException(SurveyErrorCode.FORM_VALIDATION_FAILED);
+            throw new CustomException(ErrorCode.SERVER_UNTRACKED_ERROR);
         }
     }
 }

--- a/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormCommandService.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormCommandService.java
@@ -147,7 +147,7 @@ public class FormCommandService implements FormCreator, FormUpdater, FormPublish
                         if (!isFirstRequest) {
                             redisCacheAction.incrementValue(quotaKey);
                         }
-                    } else {
+                    } else if (isEmailRequired) {
                         log.warn("[FORM:COMMAND:validationFormRequestLink] 링크 유효성 검사 후 이메일 발송 실패 - userKey: {}", userKey);
                     }
 
@@ -159,6 +159,7 @@ public class FormCommandService implements FormCreator, FormUpdater, FormPublish
             log.warn("[FORM:COMMAND] 구글폼 링크 유효성 검사 락 획득 실패 - userKey: {}", userKey);
             throw new CustomException(SurveyErrorCode.FORM_VALIDATION_PROCEED);
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             log.warn("[FORM:COMMAND] 구글폼 링크 유효성 검사 락 획득 중 에러 발생 - userKey: {}", userKey);
             throw new CustomException(SurveyErrorCode.FORM_VALIDATION_FAILED);
         }

--- a/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormCommandService.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormCommandService.java
@@ -2,7 +2,6 @@ package OneQ.OnSurvey.domain.survey.service.formRequest;
 
 import OneQ.OnSurvey.domain.member.dto.MemberSearchResult;
 import OneQ.OnSurvey.domain.member.service.MemberFinder;
-import OneQ.OnSurvey.domain.survey.SurveyErrorCode;
 import OneQ.OnSurvey.domain.survey.entity.FormRequest;
 import OneQ.OnSurvey.domain.survey.model.formRequest.FormPublishRequest;
 import OneQ.OnSurvey.domain.survey.model.formRequest.FormValidationPostResponse;
@@ -127,17 +126,22 @@ public class FormCommandService implements FormCreator, FormUpdater, FormPublish
                     String quotaKey = "ses:daily_usage:" + LocalDate.now() + ":" + userKey;
                     boolean isEmailRequired = Boolean.TRUE.equals(dto.isEmailRequired()) && EMAIL_QUOTA > redisCacheAction.getIntValue(quotaKey);
 
+                    String username = "";
                     // 이메일을 요청했으나, 일일 한도를 초과한 경우
                     if (Boolean.TRUE.equals(dto.isEmailRequired()) && !isEmailRequired) {
-                        throw new CustomException(SurveyErrorCode.FORM_VALIDATION_EMAIL_TOO_MANY_REQUEST);
+                        throw new CustomException(FORM_VALIDATION_EMAIL_TOO_MANY_REQUEST);
+                    }
+                    // 이메일을 요청하고, 한도 이내인 경우
+                    else if (isEmailRequired) {
+                        username = memberFinder.getUsernameByUserKey(userKey);
                     }
 
-                    FormValidationPayload payload = new FormValidationPayload(List.of(dto.formLink()), dto.requesterEmail(), isEmailRequired);
+                    FormValidationPayload payload = new FormValidationPayload(List.of(dto.formLink()), dto.requesterEmail(), isEmailRequired, username);
                     FormValidationPostResponse response = formRequestLambda.validateAndStashFormRequest(payload);
 
                     if (response == null) {
                         log.warn("[FORM:COMMAND:validationFormRequestLink] 구글폼 링크 유효성 검사 실패 - URL: {}", dto.formLink());
-                        throw new CustomException(SurveyErrorCode.FORM_VALIDATION_BAD_GATEWAY);
+                        throw new CustomException(FORM_VALIDATION_BAD_GATEWAY);
                     }
 
                     if (response.isEmailSent()) {
@@ -158,7 +162,7 @@ public class FormCommandService implements FormCreator, FormUpdater, FormPublish
             return formConverter.toResponse(validationResult);
         } catch (RedisException e) {
             log.warn("[FORM:COMMAND] 구글폼 링크 유효성 검사 락 획득 실패 - userKey: {}", userKey);
-            throw new CustomException(SurveyErrorCode.FORM_VALIDATION_PROCEED);
+            throw new CustomException(FORM_VALIDATION_PROCEED);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             log.warn("[FORM:COMMAND] 구글폼 링크 유효성 검사 락 획득 중 에러 발생 - userKey: {}", userKey);

--- a/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormCommandService.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormCommandService.java
@@ -38,7 +38,6 @@ import static OneQ.OnSurvey.domain.survey.SurveyErrorCode.*;
 @Transactional
 @RequiredArgsConstructor
 public class FormCommandService implements FormCreator, FormUpdater, FormPublisher {
-    private static final int EMAIL_QUOTA = 5;
 
     private final ApplicationEventPublisher eventPublisher;
     private final RedisCacheAction redisCacheAction;
@@ -51,8 +50,13 @@ public class FormCommandService implements FormCreator, FormUpdater, FormPublish
     private final MemberFinder memberFinder;
     private final SurveyCommand surveyCommand;
 
+    @Value("${external.ses.quota.hour: 20}")
+    int emailQuota;
+
     @Value("${redis.validation-key-prefix.lock:}")
     String validationLockPrefix;
+    @Value("${redis.validation-key-prefix.email-hour-usage:}")
+    String emailHourUsageKey;
 
     @Override
     public Long createFormRequest(Long userKey, Long memberId, FormRequestDto dto) {
@@ -123,20 +127,19 @@ public class FormCommandService implements FormCreator, FormUpdater, FormPublish
                 validationLockPrefix + userKey,
                 0,
                 () -> {
-                    String quotaKey = "ses:daily_usage:" + LocalDate.now() + ":" + userKey;
-                    boolean isEmailRequired = Boolean.TRUE.equals(dto.isEmailRequired()) && EMAIL_QUOTA > redisCacheAction.getIntValue(quotaKey);
+                    String quotaKey = emailHourUsageKey + LocalDate.now() + ":" + userKey;
 
-                    String username = "";
-                    // 이메일을 요청했으나, 일일 한도를 초과한 경우
-                    if (Boolean.TRUE.equals(dto.isEmailRequired()) && !isEmailRequired) {
+                    String username;
+                    // 일일 한도를 초과한 경우
+                    if (emailQuota <= redisCacheAction.getIntValue(quotaKey)) {
                         throw new CustomException(FORM_VALIDATION_EMAIL_TOO_MANY_REQUEST);
                     }
-                    // 이메일을 요청하고, 한도 이내인 경우
-                    else if (isEmailRequired) {
+                    // 일일 한도 이내인 경우
+                    else {
                         username = memberFinder.getUsernameByUserKey(userKey);
                     }
 
-                    FormValidationPayload payload = new FormValidationPayload(List.of(dto.formLink()), dto.requesterEmail(), isEmailRequired, username);
+                    FormValidationPayload payload = new FormValidationPayload(List.of(dto.formLink()), dto.requesterEmail(), username);
                     FormValidationPostResponse response = formRequestLambda.validateAndStashFormRequest(payload);
 
                     if (response == null) {
@@ -145,14 +148,15 @@ public class FormCommandService implements FormCreator, FormUpdater, FormPublish
                     }
 
                     if (response.isEmailSent()) {
+                        LocalDateTime now = LocalDateTime.now();
                         boolean isFirstRequest = redisCacheAction.setValueIfAbsent(
                             quotaKey, "1",
-                            Duration.between(LocalDateTime.now(), LocalDate.now().atStartOfDay().plusDays(1))
+                            Duration.between(now, now.plusHours(1))
                         );
                         if (!isFirstRequest) {
                             redisCacheAction.incrementValue(quotaKey);
                         }
-                    } else if (isEmailRequired) {
+                    } else {
                         log.warn("[FORM:COMMAND:validationFormRequestLink] 링크 유효성 검사 후 이메일 발송 실패 - userKey: {}", userKey);
                     }
 

--- a/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormCommandService.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormCommandService.java
@@ -147,14 +147,14 @@ public class FormCommandService implements FormCreator, FormUpdater, FormPublish
                         throw new CustomException(FORM_VALIDATION_BAD_GATEWAY);
                     }
 
-                    if (response.isEmailSent()) {
+                    if (response.emailSent() > 0) {
                         LocalDateTime now = LocalDateTime.now();
                         boolean isFirstRequest = redisCacheAction.setValueIfAbsent(
-                            quotaKey, "1",
+                            quotaKey,  String.valueOf(response.emailSent()),
                             Duration.between(now, now.plusHours(1))
                         );
                         if (!isFirstRequest) {
-                            redisCacheAction.incrementValue(quotaKey);
+                            redisCacheAction.incrementValue(quotaKey, response.emailSent());
                         }
                     } else {
                         log.warn("[FORM:COMMAND:validationFormRequestLink] 링크 유효성 검사 후 이메일 발송 실패 - userKey: {}", userKey);

--- a/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormCommandService.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormCommandService.java
@@ -124,10 +124,10 @@ public class FormCommandService implements FormCreator, FormUpdater, FormPublish
                 0,
                 () -> {
                     String quotaKey = "ses:daily_usage:" + LocalDate.now() + ":" + userKey;
-                    boolean isEmailRequired = dto.isEmailRequired() && EMAIL_QUOTA > redisCacheAction.getIntValue(quotaKey);
+                    boolean isEmailRequired = Boolean.TRUE.equals(dto.isEmailRequired()) && EMAIL_QUOTA > redisCacheAction.getIntValue(quotaKey);
 
                     // 이메일을 요청했으나, 일일 한도를 초과한 경우
-                    if (dto.isEmailRequired() && !isEmailRequired) {
+                    if (Boolean.TRUE.equals(dto.isEmailRequired()) && !isEmailRequired) {
                         throw new CustomException(SurveyErrorCode.FORM_VALIDATION_EMAIL_TOO_MANY_REQUEST);
                     }
 

--- a/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormCommandService.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormCommandService.java
@@ -16,12 +16,19 @@ import OneQ.OnSurvey.domain.survey.repository.formRequest.FormRequestRepository;
 import OneQ.OnSurvey.domain.survey.service.command.SurveyCommand;
 import OneQ.OnSurvey.domain.survey.service.query.SurveyQueryService;
 import OneQ.OnSurvey.global.common.exception.CustomException;
+import OneQ.OnSurvey.global.infra.redis.RedisCacheAction;
+import OneQ.OnSurvey.global.infra.redis.RedisLockAction;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.redisson.client.RedisException;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static OneQ.OnSurvey.domain.survey.SurveyErrorCode.*;
@@ -31,14 +38,21 @@ import static OneQ.OnSurvey.domain.survey.SurveyErrorCode.*;
 @Transactional
 @RequiredArgsConstructor
 public class FormCommandService implements FormCreator, FormUpdater, FormPublisher {
+    private static final int EMAIL_QUOTA = 5;
 
     private final ApplicationEventPublisher eventPublisher;
+    private final RedisCacheAction redisCacheAction;
+    private final RedisLockAction redisLockAction;
+
     private final FormConverter formConverter;
     private final FormRequestLambda formRequestLambda;
     private final FormRequestRepository formRequestRepository;
     private final SurveyQueryService surveyQueryService;
     private final MemberFinder memberFinder;
     private final SurveyCommand surveyCommand;
+
+    @Value("${redis.validation-key-prefix.lock:}")
+    String validationLockPrefix;
 
     @Override
     public Long createFormRequest(Long userKey, Long memberId, FormRequestDto dto) {
@@ -103,14 +117,50 @@ public class FormCommandService implements FormCreator, FormUpdater, FormPublish
      * @return 변환된 문항 수 / 변환되지 않은 문항 및 사유
      */
     @Override
-    public FormValidationResponse validationFormRequestLink(FormValidationRequestDto dto) {
-        FormValidationPayload payload = new FormValidationPayload(List.of(dto.formLink()), dto.requesterEmail());
-        FormValidationPostResponse validationResult = formRequestLambda.validateAndStashFormRequest(payload);
+    public FormValidationResponse validationFormRequestLink(Long userKey, FormValidationRequestDto dto) {
+        try {
+            FormValidationPostResponse validationResult = redisLockAction.executeWithLock(
+                validationLockPrefix + userKey,
+                0,
+                () -> {
+                    String quotaKey = "ses:daily_usage:" + LocalDate.now() + ":" + userKey;
+                    boolean isEmailRequired = dto.isEmailRequired() && EMAIL_QUOTA > redisCacheAction.getIntValue(quotaKey);
 
-        if (validationResult == null) {
-            log.warn("[FormCommandService:validationFormRequestLink] 구글폼 링크 유효성 검사 실패 - URL: {}", dto.formLink());
+                    // 이메일을 요청했으나, 일일 한도를 초과한 경우
+                    if (dto.isEmailRequired() && !isEmailRequired) {
+                        throw new CustomException(SurveyErrorCode.FORM_VALIDATION_EMAIL_TOO_MANY_REQUEST);
+                    }
+
+                    FormValidationPayload payload = new FormValidationPayload(List.of(dto.formLink()), dto.requesterEmail(), isEmailRequired);
+                    FormValidationPostResponse response = formRequestLambda.validateAndStashFormRequest(payload);
+
+                    if (response == null) {
+                        log.warn("[FORM:COMMAND:validationFormRequestLink] 구글폼 링크 유효성 검사 실패 - URL: {}", dto.formLink());
+                        throw new CustomException(SurveyErrorCode.FORM_VALIDATION_FAILED);
+                    }
+
+                    if (response.isEmailSent()) {
+                        boolean isFirstRequest = redisCacheAction.setValueIfAbsent(
+                            quotaKey, "1",
+                            Duration.between(LocalDateTime.now(), LocalDate.now().atStartOfDay().plusDays(1))
+                        );
+                        if (!isFirstRequest) {
+                            redisCacheAction.incrementValue(quotaKey);
+                        }
+                    } else {
+                        log.warn("[FORM:COMMAND:validationFormRequestLink] 링크 유효성 검사 후 이메일 발송 실패 - userKey: {}", userKey);
+                    }
+
+                    return response;
+                });
+
+            return formConverter.toResponse(validationResult);
+        } catch (RedisException e) {
+            log.warn("[FORM:COMMAND] 구글폼 링크 유효성 검사 락 획득 실패 - userKey: {}", userKey);
+            throw new CustomException(SurveyErrorCode.FORM_VALIDATION_PROCEED);
+        } catch (InterruptedException e) {
+            log.warn("[FORM:COMMAND] 구글폼 링크 유효성 검사 락 획득 중 에러 발생 - userKey: {}", userKey);
             throw new CustomException(SurveyErrorCode.FORM_VALIDATION_FAILED);
         }
-        return formConverter.toResponse(validationResult);
     }
 }

--- a/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormConverter.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormConverter.java
@@ -129,7 +129,7 @@ public class FormConverter {
             .map(this::mapToResult)
             .toList();
 
-        return new FormValidationResponse(results, dto.isEmailSent());
+        return new FormValidationResponse(results, dto.emailSent());
     }
 
     private FormValidationResponse.Result mapToResult(FormValidationPostResponse.Result r) {

--- a/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormConverter.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormConverter.java
@@ -138,7 +138,7 @@ public class FormConverter {
                 r.url(),
                 r.counts().total(),
                 r.counts().convertible(),
-                r.counts().unconvertible(),
+                r.counts().inconvertible(),
                 mapInconvertible(r.inconvertibleDetails()),
                 mapConvertible(r.convertibleDetails())
             );

--- a/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormConverter.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormConverter.java
@@ -129,7 +129,7 @@ public class FormConverter {
             .map(this::mapToResult)
             .toList();
 
-        return new FormValidationResponse(results);
+        return new FormValidationResponse(results, dto.isEmailSent());
     }
 
     private FormValidationResponse.Result mapToResult(FormValidationPostResponse.Result r) {

--- a/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormCreator.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormCreator.java
@@ -6,5 +6,5 @@ import OneQ.OnSurvey.domain.survey.model.formRequest.FormRequestDto;
 
 public interface FormCreator {
     Long createFormRequest(Long userKey, Long memberId, FormRequestDto dto);
-    FormValidationResponse validationFormRequestLink(FormValidationRequestDto dto);
+    FormValidationResponse validationFormRequestLink(Long userKey, FormValidationRequestDto dto);
 }

--- a/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormFinder.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormFinder.java
@@ -2,6 +2,7 @@ package OneQ.OnSurvey.domain.survey.service.formRequest;
 
 import OneQ.OnSurvey.domain.survey.model.formRequest.FormListResponse;
 import OneQ.OnSurvey.domain.survey.model.formRequest.FormRequestResponse;
+import OneQ.OnSurvey.domain.survey.model.formRequest.FormValidationEmailQuotaResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -16,4 +17,5 @@ public interface FormFinder {
      * @return 페이지네이션된 폼 요청 목록
      */
     Page<FormRequestResponse> getFormRequests(String email, Boolean isRegistered, Pageable pageable);
+    FormValidationEmailQuotaResponse getEmailQuota(Long userKey);
 }

--- a/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormQueryService.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormQueryService.java
@@ -8,6 +8,7 @@ import OneQ.OnSurvey.domain.survey.repository.formRequest.FormRequestRepository;
 import OneQ.OnSurvey.global.infra.redis.RedisCacheAction;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -21,11 +22,15 @@ import java.util.List;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class FormQueryService implements FormFinder {
-    private static final int EMAIL_QUOTA = 5;
-
     private final RedisCacheAction redisCacheAction;
 
     private final FormRequestRepository formRequestRepository;
+
+    @Value("${external.ses.quota.hour:20}")
+    int emailQuota;
+
+    @Value("${redis.validation-key-prefix.email-hour-usage:}")
+    String emailHourUsageKey;
 
     @Override
     public FormListResponse getAllUnregisteredRequests() {
@@ -42,10 +47,10 @@ public class FormQueryService implements FormFinder {
 
     @Override
     public FormValidationEmailQuotaResponse getEmailQuota(Long userKey) {
-        String quotaKey = "ses:daily_usage:" + LocalDate.now() + ":" + userKey;
+        String quotaKey = emailHourUsageKey + LocalDate.now() + ":" + userKey;
         int usedCount = redisCacheAction.getIntValue(quotaKey);
-        log.info("[FORM:FINDER] 이메일 수신 한도 잔량 userKey - {}, {}", userKey, EMAIL_QUOTA - usedCount);
+        log.info("[FORM:FINDER] 이메일 수신 한도 잔량 userKey - {}, {}", userKey, emailQuota - usedCount);
 
-        return new FormValidationEmailQuotaResponse(EMAIL_QUOTA - usedCount);
+        return new FormValidationEmailQuotaResponse(emailQuota - usedCount);
     }
 }

--- a/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormQueryService.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormQueryService.java
@@ -3,19 +3,27 @@ package OneQ.OnSurvey.domain.survey.service.formRequest;
 import OneQ.OnSurvey.domain.survey.entity.FormRequest;
 import OneQ.OnSurvey.domain.survey.model.formRequest.FormListResponse;
 import OneQ.OnSurvey.domain.survey.model.formRequest.FormRequestResponse;
+import OneQ.OnSurvey.domain.survey.model.formRequest.FormValidationEmailQuotaResponse;
 import OneQ.OnSurvey.domain.survey.repository.formRequest.FormRequestRepository;
+import OneQ.OnSurvey.global.infra.redis.RedisCacheAction;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
 
+@Slf4j
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class FormQueryService implements FormFinder {
+    private static final int EMAIL_QUOTA = 5;
+
+    private final RedisCacheAction redisCacheAction;
 
     private final FormRequestRepository formRequestRepository;
 
@@ -30,5 +38,14 @@ public class FormQueryService implements FormFinder {
         Page<FormRequest> formRequestPage = formRequestRepository.findAllWithFilters(email, isRegistered, pageable);
 
         return formRequestPage.map(FormRequestResponse::of);
+    }
+
+    @Override
+    public FormValidationEmailQuotaResponse getEmailQuota(Long userKey) {
+        String quotaKey = "ses:daily_usage:" + LocalDate.now() + ":" + userKey;
+        int usedCount = redisCacheAction.getIntValue(quotaKey);
+        log.info("[FORM:FINDER] 이메일 수신 한도 잔량 userKey - {}, {}", userKey, EMAIL_QUOTA - usedCount);
+
+        return new FormValidationEmailQuotaResponse(EMAIL_QUOTA - usedCount);
     }
 }

--- a/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormRequestLambda.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormRequestLambda.java
@@ -39,8 +39,8 @@ public class FormRequestLambda {
             .timeout(Duration.ofSeconds(timeout))
             .retryWhen(Retry.backoff(2, Duration.ofSeconds(3)))
             .onErrorMap(e -> {
-                log.error("[FormRequestLambda:validateAndStashFormRequest] 구글폼 링크 유효성 검사 실패 - URLs: {}, error: {}", payload.urls(), e.getMessage(), e);
-                throw new CustomException(SurveyErrorCode.FORM_VALIDATION_FAILED);
+                log.error("[FORM:LAMBDA:validateAndStashFormRequest] 구글폼 링크 유효성 검사 실패 - URLs: {}, error: {}", payload.urls(), e.getMessage(), e);
+                throw new CustomException(SurveyErrorCode.FORM_VALIDATION_BAD_GATEWAY);
             })
             .block();
 


### PR DESCRIPTION
### ✨ Related Issue
- [OMF-297 폼링크 유효성 검사 중복요청 방지 및 이메일 전송 일일 한도 설정](https://onsurvey.atlassian.net/browse/OMF-297)

---

### 📌 Task Details
- [x] `validation lock`을 통해 중복요청(따닥) 시 즉시-실패 반환
- [x] 이메일 요청 한도 설정

---

### 💬 Review Requirements (Optional)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 구글 폼 유효성 검사 결과 이메일 발송 시 사용자별 일일 한도(5회) 적용
  * 이메일 할당량 확인 API 추가
  * 유효성 검사 진행 상태 및 일일 한도 초과 상태 코드 추가
  * 사용자별 동시성 제어로 안정성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->