### PR TITLE
🐛 OMF-301 미지원 문항의 섹션 순서 필드 추가

### DIFF
--- a/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/FormValidationPostResponse.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/FormValidationPostResponse.java
@@ -39,6 +39,7 @@ public record FormValidationPostResponse(
         String title,
         String type,
         String reason,
+        int section,
         int order
     ) { }
 

--- a/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/FormValidationResponse.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/model/formRequest/FormValidationResponse.java
@@ -18,14 +18,16 @@ public record FormValidationResponse(
                     "inconvertible": 8,
                     "inconvertibleDetails": [
                         {
-                            "title": "비디오 문항 제목",
+                            "title": "스킵된 1번 섹션의 비디오 문항 제목",
                             "type": "VIDEO",
                             "reason": "비디오 문항 미지원",
-                            "order": 6
+                            "section": 0,
+                            "order": 1
                         }, {
                             "title": "시간 문항 제목",
                             "type": "TIME",
                             "reason": "시간 문항 미지원",
+                            "section": 3,
                             "order": 9
                         }
                     ],
@@ -115,6 +117,7 @@ public record FormValidationResponse(
         String title,
         String type,
         String reason,
+        int section,
         int order
     ) { }
 

--- a/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormConverter.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormConverter.java
@@ -157,7 +157,7 @@ public class FormConverter {
         if (details == null || details.isEmpty()) return List.of();
 
         return details.stream()
-            .map(i -> new FormValidationResponse.Inconvertible(i.title(), i.type(), i.reason(), i.order()))
+            .map(i -> new FormValidationResponse.Inconvertible(i.title(), i.type(), i.reason(), i.section(), i.order()))
             .toList();
     }
 


### PR DESCRIPTION
### ✨ Related Issue
- [OMF-301 미지원 문항의 섹션 순서 필드 추가](https://onsurvey.atlassian.net/browse/OMF-301?atlOrigin=eyJpIjoiNGI4ZDJkNzQ3YTEzNGU2N2E1NmQxZTliZjIwYTRhMWIiLCJwIjoiaiJ9)

---

### 📌 Task Details
- [x] 미지원 문항의 구글폼 내 섹션 순서 반환하도록 `section` 필드를 추가
- [x] 구글폼 1번섹션의 모든 문항이 미지원되어 1번섹션이 스킵된 상태로 변환이 이루어진 경우, 기존 1번섹션에 속하는 문항들은 `section` 값으로 0을 갖도록 함

---

### 💬 Review Requirements (Optional)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 개선사항

* **새로운 기능**
  * 양식 검증 응답에 섹션 정보가 추가되어 사용자가 오류 발생 위치를 더 명확하게 파악할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->