### PR TITLE
✨ OMF-312 그리드 문항 응답 CSV추출 최적화

### DIFF
--- a/src/main/java/OneQ/OnSurvey/domain/survey/model/export/SurveyAnswerProjection.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/model/export/SurveyAnswerProjection.java
@@ -9,4 +9,6 @@ public class SurveyAnswerProjection {
     private final Long memberId;
     private final Long questionId;
     private final String content;
+    // 그리드 이외 타입은 기본값 0을 가지도록 함.
+    private final Integer gridRowOrder;
 }

--- a/src/main/java/OneQ/OnSurvey/domain/survey/model/export/SurveyQuestionHeader.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/model/export/SurveyQuestionHeader.java
@@ -9,4 +9,6 @@ public class SurveyQuestionHeader {
     private final Long questionId;
     private final Integer orderNo;
     private final String title;
+    private final Integer rowOrder;
+    private final String rowContent;
 }

--- a/src/main/java/OneQ/OnSurvey/domain/survey/repository/export/SurveyExportRepositoryImpl.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/repository/export/SurveyExportRepositoryImpl.java
@@ -58,7 +58,7 @@ public class SurveyExportRepositoryImpl implements SurveyExportRepository {
                 .join(question).on(question.questionId.eq(questionAnswer.questionId))
                 .join(member).on(member.id.eq(questionAnswer.memberId))
                 .join(response).on(response.surveyId.eq(surveyId).and(response.memberId.eq(questionAnswer.memberId)))
-                .where(question.surveyId.eq(surveyId))
+                .where(question.surveyId.eq(surveyId).and(response.isResponded.isTrue()))
                 .distinct()
                 .orderBy(member.id.asc())
                 .fetch();
@@ -77,7 +77,7 @@ public class SurveyExportRepositoryImpl implements SurveyExportRepository {
                 .from(questionAnswer)
                 .join(question).on(question.questionId.eq(questionAnswer.questionId))
                 .join(response).on(response.surveyId.eq(surveyId).and(response.memberId.eq(questionAnswer.memberId)))
-                .where(question.surveyId.eq(surveyId))
+                .where(question.surveyId.eq(surveyId).and(response.isResponded.isTrue()))
                 .orderBy(response.updatedAt.asc(), question.order.asc(), questionAnswer.gridRowOrder.asc())
                 .fetch();
     }

--- a/src/main/java/OneQ/OnSurvey/domain/survey/repository/export/SurveyExportRepositoryImpl.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/repository/export/SurveyExportRepositoryImpl.java
@@ -13,6 +13,7 @@ import java.util.List;
 import static OneQ.OnSurvey.domain.member.QMember.member;
 import static OneQ.OnSurvey.domain.participation.entity.QQuestionAnswer.questionAnswer;
 import static OneQ.OnSurvey.domain.participation.entity.QResponse.response;
+import static OneQ.OnSurvey.domain.question.entity.QGridOption.gridOption;
 import static OneQ.OnSurvey.domain.question.entity.QQuestion.question;
 import static OneQ.OnSurvey.domain.survey.entity.QSurvey.survey;
 
@@ -29,11 +30,17 @@ public class SurveyExportRepositoryImpl implements SurveyExportRepository {
                         SurveyQuestionHeader.class,
                         question.questionId,
                         question.order,
-                        question.title
+                        question.title,
+                        gridOption.order.coalesce(0),
+                        gridOption.content
                 ))
                 .from(question)
+                .leftJoin(gridOption).on(
+                    question.questionId.eq(gridOption.questionId),
+                    gridOption.isRow.isTrue()
+                )
                 .where(question.surveyId.eq(surveyId))
-                .orderBy(question.order.asc())
+                .orderBy(question.order.asc(), gridOption.order.asc())
                 .fetch();
     }
 
@@ -51,7 +58,7 @@ public class SurveyExportRepositoryImpl implements SurveyExportRepository {
                 .join(question).on(question.questionId.eq(questionAnswer.questionId))
                 .join(member).on(member.id.eq(questionAnswer.memberId))
                 .join(response).on(response.surveyId.eq(surveyId).and(response.memberId.eq(questionAnswer.memberId)))
-                .where(question.surveyId.eq(surveyId).and(response.isResponded.isTrue()))
+                .where(question.surveyId.eq(surveyId))
                 .distinct()
                 .orderBy(member.id.asc())
                 .fetch();
@@ -64,12 +71,14 @@ public class SurveyExportRepositoryImpl implements SurveyExportRepository {
                         SurveyAnswerProjection.class,
                         questionAnswer.memberId,
                         questionAnswer.questionId,
-                        questionAnswer.content
+                        questionAnswer.content,
+                        questionAnswer.gridRowOrder.coalesce(0)
                 ))
                 .from(questionAnswer)
                 .join(question).on(question.questionId.eq(questionAnswer.questionId))
                 .join(response).on(response.surveyId.eq(surveyId).and(response.memberId.eq(questionAnswer.memberId)))
-                .where(question.surveyId.eq(surveyId).and(response.isResponded.isTrue()))
+                .where(question.surveyId.eq(surveyId))
+                .orderBy(response.updatedAt.asc(), question.order.asc(), questionAnswer.gridRowOrder.asc())
                 .fetch();
     }
 

--- a/src/main/java/OneQ/OnSurvey/domain/survey/service/export/SurveyExportService.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/service/export/SurveyExportService.java
@@ -56,10 +56,11 @@ public class SurveyExportService implements SurveyExport {
             log.info("[SurveyExport] fetched. surveyId={}, questions={}, members={}, answers={}",
                     surveyId, headers.size(), members.size(), answers.size());
 
-            Map<Long, Map<Long, Set<String>>> answerMap = new HashMap<>();
+            Map<Long, Map<Long, Map<Integer, Set<String>>>> answerMap = new HashMap<>();
             for (SurveyAnswerProjection a : answers) {
                 answerMap.computeIfAbsent(a.getMemberId(), k -> new HashMap<>())
-                    .computeIfAbsent(a.getQuestionId(), k -> new TreeSet<>())
+                    .computeIfAbsent(a.getQuestionId(), k -> new HashMap<>())
+                    .computeIfAbsent(a.getGridRowOrder() , k -> new TreeSet<>())
                     .add(a.getContent());
             }
 
@@ -71,7 +72,7 @@ public class SurveyExportService implements SurveyExport {
             if (includeGender) headerCols.add("gender");
             headerCols.add("residence");
             for (SurveyQuestionHeader h : headers) {
-                headerCols.add("Q" + nvlInt(h.getOrderNo() + 1) + ". " + nvl(h.getTitle()));
+                headerCols.add("Q" + nvlInt(h.getOrderNo() + 1) + ". " + nvl(h.getTitle()) + gridNvl(h.getRowContent()));
             }
             sb.append(String.join(",", escapeCsv(headerCols))).append("\n");
 
@@ -90,9 +91,11 @@ public class SurveyExportService implements SurveyExport {
 
                 row.add(nvl(m.getResidence()));
 
-                Map<Long, Set<String>> memberAnswers = answerMap.getOrDefault(m.getMemberId(), Map.of());
+                Map<Long, Map<Integer, Set<String>>> memberAnswers = answerMap.getOrDefault(m.getMemberId(), Map.of());
                 for (SurveyQuestionHeader h : headers) {
-                    row.add(nvl(String.join(",", memberAnswers.getOrDefault(h.getQuestionId(), Set.of()))));
+                    row.add(nvl(String.join(",", memberAnswers.getOrDefault(
+                        h.getQuestionId(), Map.of()).getOrDefault(
+                            h.getRowOrder(), Set.of()))));
                 }
 
                 sb.append(String.join(",", escapeCsv(row))).append("\n");
@@ -139,6 +142,9 @@ public class SurveyExportService implements SurveyExport {
 
     private String nvl(String s) { return s == null ? "" : s; }
     private String nvlInt(Integer i) { return i == null ? "" : String.valueOf(i); }
+    private String gridNvl(String s) {
+        return s == null ? "" : " [" + s + "]";
+    }
 
     private List<String> escapeCsv(List<String> vals) {
         List<String> out = new ArrayList<>(vals.size());


### PR DESCRIPTION
### ✨ Related Issue
- [OMF-312 그리드 문항 응답 CSV추출 최적화](https://onsurvey.atlassian.net/browse/OMF-312)

---

### 📌 Task Details
- [x] 그리드 문항 응답을 행별로 집계 가능하도록 `rowOrder`에 대한 `Map`을 추가
  - `memberId` - `questionId` - `rowOrder`(그리드 외 문항은 기본값 `0`으로 key 설정) - `content`

---

### 💬 Review Requirements (Optional)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 설문 내보내기 시 그리드 행 정보가 올바르게 포함되도록 개선했습니다.
  * CSV 내보내기 구조를 개선하여 표 형식 설문 문항을 더욱 정확하게 처리합니다.
  * 열 제목에 그리드 행 콘텐츠 정보를 추가하여 더 상세한 정보를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->