### PR TITLE
🐛 OMF-328 홈 결제시 코인 차감 로직 제거

### DIFF
--- a/src/main/java/OneQ/OnSurvey/domain/survey/service/command/SurveyCommand.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/service/command/SurveyCommand.java
@@ -14,6 +14,7 @@ import java.util.Set;
 public interface SurveyCommand {
     SurveyFormResponse upsertSurvey(Long memberId, Long surveyId, SurveyFormCreateRequest request);
     SurveyFormResponse submitSurvey(Long userKey, Long surveyId, SurveyFormRequest request);
+    SurveyFormResponse submitHomeFormSurvey(Long userKey, Long surveyId, SurveyFormRequest request);
     SurveyFormResponse submitFreeSurvey(Long userKey, Long surveyId, FreeSurveyFormRequest request);
     ScreeningResponse upsertScreening(Long surveyId, String content, Boolean answer);
     Boolean refundSurvey(Long memberId, Long surveyId);

--- a/src/main/java/OneQ/OnSurvey/domain/survey/service/command/SurveyCommandService.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/service/command/SurveyCommandService.java
@@ -161,6 +161,42 @@ public class SurveyCommandService implements SurveyCommand {
 
 
     @Override
+    public SurveyFormResponse submitHomeFormSurvey(Long userKey, Long surveyId, SurveyFormRequest request) {
+        Survey survey = getSurvey(surveyId);
+        validateMember(userKey);
+
+        Set<AgeRange> ages = (request.ages() == null) ? Set.of() : new HashSet<>(request.ages());
+
+        Long discountCodeId = null;
+        if (request.discountCode() != null && !request.discountCode().isBlank()) {
+            DiscountCode discountCode = discountCodeQueryService.getByCode(request.discountCode());
+            discountCodeId = discountCode.getId();
+            log.info("[HomeFormSubmit] 할인 코드 저장 - surveyId={}, org={}", surveyId, discountCode.getOrganizationName());
+        }
+
+        survey.updateSurvey(survey.getTitle(), survey.getDescription(), request.deadline(), request.totalCoin());
+
+        int questionCount = questionQueryService.countQuestionsBySurveyId(surveyId);
+        int resolvedPromotionAmount = promotionTierResolver.resolveAmountByQuestionCount(questionCount);
+
+        Set<Residence> residences = (request.residences() == null) ? Set.of() : new HashSet<>(request.residences());
+
+        SurveyInfo info = upsertSurveyInfo(
+                surveyId,
+                request.dueCount(),
+                request.gender(),
+                ages,
+                residences,
+                resolvedPromotionAmount,
+                discountCodeId,
+                true
+        );
+
+        log.info("[HomeFormSubmit] 홈결제 설문 제출 완료 (코인 차감 없음) - surveyId={}", surveyId);
+        return finalizeSubmit(userKey, surveyId, survey, info, request.dueCount(), request.deadline(), request.totalCoin());
+    }
+
+    @Override
     public SurveyFormResponse submitFreeSurvey(Long userKey, Long surveyId, FreeSurveyFormRequest request) {
         Survey survey = getSurvey(surveyId);
         validateMember(userKey);

--- a/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormEventListener.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/service/formRequest/FormEventListener.java
@@ -102,7 +102,7 @@ public class FormEventListener {
                         } else {
                             surveyCommand.upsertInterest(conversionSurveyId, Set.of(Interest.BUSINESS));
                         }
-                        surveyCommand.submitSurvey(event.userKey(), conversionSurveyId, event.surveyForm());
+                        surveyCommand.submitHomeFormSurvey(event.userKey(), conversionSurveyId, event.surveyForm());
 
                         successCount.incrementAndGet();
                         return SurveyConversionAlert.ConversionDetails.success(


### PR DESCRIPTION
### ✨ Related Issue
- [OMF-328](https://onsurvey.atlassian.net/browse/OMF-328)
---

### 📌 Task Details
- SurveyCommand.java — submitHomeFormSurvey() 인터페이스 추가
- SurveyCommandService.java — 코인 차감 없는 구현체 추가                                                                                                                                                                              
- FormEventListener.java — submitHomeFormSurvey() 호출로 변경

---

### 💬 Review Requirements (Optional)



[OMF-328]: https://onsurvey.atlassian.net/browse/OMF-328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **새로운 기능**
  * 홈 폼 설문 제출 기능이 추가되었습니다. 사용자는 이제 홈 화면에서 직접 설문에 참여할 수 있으며, 별도의 보상 처리 로직이 적용됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->