### PR TITLE
✨ [OMF-337] 열려있는 설문 수 및 최고 참여 보상 코인 조회 API 추가

### DIFF
--- a/src/main/java/OneQ/OnSurvey/domain/survey/controller/SurveyStatsController.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/controller/SurveyStatsController.java
@@ -1,8 +1,11 @@
 package OneQ.OnSurvey.domain.survey.controller;
 
 import OneQ.OnSurvey.domain.survey.model.dto.GlobalStats;
+import OneQ.OnSurvey.domain.survey.model.dto.OpenSurveyStats;
 import OneQ.OnSurvey.domain.survey.model.response.GlobalStatsResponse;
+import OneQ.OnSurvey.domain.survey.model.response.OpenSurveyStatsResponse;
 import OneQ.OnSurvey.domain.survey.service.SurveyGlobalStatsService;
+import OneQ.OnSurvey.domain.survey.service.query.SurveyQuery;
 import OneQ.OnSurvey.global.common.response.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
@@ -16,11 +19,19 @@ import org.springframework.web.bind.annotation.RestController;
 public class SurveyStatsController {
 
     private final SurveyGlobalStatsService surveyGlobalStatsService;
+    private final SurveyQuery surveyQuery;
 
     @GetMapping("/global-stats")
     @Operation(summary = "전체 설문 전역 통계 조회", description = "전체 설문에 대한 총 목표 수/참여자 수/프로모션 지급자 수/일간 활성 사용자 수를 반환합니다.")
     public SuccessResponse<GlobalStatsResponse> getGlobalStats() {
         GlobalStats stats = surveyGlobalStatsService.getStats();
         return SuccessResponse.ok(GlobalStatsResponse.from(stats));
+    }
+
+    @GetMapping("/open-stats")
+    @Operation(summary = "열린 설문 통계 조회", description = "현재 진행 중인 설문 수와 가장 높은 참여 보상 코인 금액을 반환합니다.")
+    public SuccessResponse<OpenSurveyStatsResponse> getOpenStats() {
+        OpenSurveyStats stats = surveyQuery.getOpenSurveyStats();
+        return SuccessResponse.ok(OpenSurveyStatsResponse.from(stats));
     }
 }

--- a/src/main/java/OneQ/OnSurvey/domain/survey/model/dto/OpenSurveyStats.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/model/dto/OpenSurveyStats.java
@@ -1,0 +1,10 @@
+package OneQ.OnSurvey.domain.survey.model.dto;
+
+public record OpenSurveyStats(
+    Long openSurveyCount,
+    Integer maxRewardCoin
+) {
+    public static OpenSurveyStats of(Long openSurveyCount, Integer maxRewardCoin) {
+        return new OpenSurveyStats(openSurveyCount, maxRewardCoin != null ? maxRewardCoin : 0);
+    }
+}

--- a/src/main/java/OneQ/OnSurvey/domain/survey/model/dto/OpenSurveyStats.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/model/dto/OpenSurveyStats.java
@@ -5,6 +5,9 @@ public record OpenSurveyStats(
     Integer maxRewardCoin
 ) {
     public static OpenSurveyStats of(Long openSurveyCount, Integer maxRewardCoin) {
-        return new OpenSurveyStats(openSurveyCount, maxRewardCoin != null ? maxRewardCoin : 0);
+        return new OpenSurveyStats(
+            openSurveyCount != null ? openSurveyCount : 0L,
+            maxRewardCoin != null ? maxRewardCoin : 0
+        );
     }
 }

--- a/src/main/java/OneQ/OnSurvey/domain/survey/model/response/OpenSurveyStatsResponse.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/model/response/OpenSurveyStatsResponse.java
@@ -1,0 +1,12 @@
+package OneQ.OnSurvey.domain.survey.model.response;
+
+import OneQ.OnSurvey.domain.survey.model.dto.OpenSurveyStats;
+
+public record OpenSurveyStatsResponse(
+    Long openSurveyCount,
+    Integer maxRewardCoin
+) {
+    public static OpenSurveyStatsResponse from(OpenSurveyStats stats) {
+        return new OpenSurveyStatsResponse(stats.openSurveyCount(), stats.maxRewardCoin());
+    }
+}

--- a/src/main/java/OneQ/OnSurvey/domain/survey/repository/SurveyRepository.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/repository/SurveyRepository.java
@@ -5,6 +5,7 @@ import OneQ.OnSurvey.domain.participation.model.dto.ParticipationStatus;
 import OneQ.OnSurvey.domain.survey.entity.Survey;
 import OneQ.OnSurvey.domain.survey.model.SurveyStatus;
 import OneQ.OnSurvey.domain.survey.model.dto.OngoingSurveyStats;
+import OneQ.OnSurvey.domain.survey.model.dto.OpenSurveyStats;
 import OneQ.OnSurvey.domain.survey.model.dto.SurveyDetailData;
 import OneQ.OnSurvey.domain.survey.model.dto.SurveyListView;
 import OneQ.OnSurvey.domain.survey.model.dto.SurveySearchQuery;
@@ -37,4 +38,5 @@ public interface SurveyRepository {
     List<Long> closeDueSurveys();
 
     List<OngoingSurveyStats> findOngoingSurveys();
+    OpenSurveyStats findOpenSurveyStats();
 }

--- a/src/main/java/OneQ/OnSurvey/domain/survey/repository/SurveyRepositoryImpl.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/repository/SurveyRepositoryImpl.java
@@ -9,6 +9,7 @@ import OneQ.OnSurvey.domain.survey.model.Gender;
 import OneQ.OnSurvey.domain.survey.model.Residence;
 import OneQ.OnSurvey.domain.survey.model.SurveyStatus;
 import OneQ.OnSurvey.domain.survey.model.dto.OngoingSurveyStats;
+import OneQ.OnSurvey.domain.survey.model.dto.OpenSurveyStats;
 import OneQ.OnSurvey.domain.survey.model.dto.SurveyDetailData;
 import OneQ.OnSurvey.domain.survey.model.dto.SurveyListView;
 import OneQ.OnSurvey.domain.survey.model.dto.SurveySearchQuery;
@@ -318,5 +319,19 @@ public class SurveyRepositoryImpl implements SurveyRepository {
             .where(survey.status.eq(SurveyStatus.ONGOING))
             .orderBy(survey.id.desc())
             .fetch();
+    }
+
+    @Override
+    public OpenSurveyStats findOpenSurveyStats() {
+        Tuple result = jpaQueryFactory
+            .select(survey.count(), surveyInfo.promotionAmount.max())
+            .from(survey)
+            .leftJoin(surveyInfo).on(survey.id.eq(surveyInfo.surveyId))
+            .where(survey.status.eq(SurveyStatus.ONGOING))
+            .fetchOne();
+
+        Long count = result != null ? result.get(survey.count()) : 0L;
+        Integer maxCoin = result != null ? result.get(surveyInfo.promotionAmount.max()) : null;
+        return OpenSurveyStats.of(count != null ? count : 0L, maxCoin);
     }
 }

--- a/src/main/java/OneQ/OnSurvey/domain/survey/repository/SurveyRepositoryImpl.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/repository/SurveyRepositoryImpl.java
@@ -330,8 +330,11 @@ public class SurveyRepositoryImpl implements SurveyRepository {
             .where(survey.status.eq(SurveyStatus.ONGOING))
             .fetchOne();
 
-        Long count = result != null ? result.get(survey.count()) : 0L;
-        Integer maxCoin = result != null ? result.get(surveyInfo.promotionAmount.max()) : null;
-        return OpenSurveyStats.of(count != null ? count : 0L, maxCoin);
+        if (result == null) {
+            return OpenSurveyStats.of(0L, null);
+        }
+        Long count = result.get(survey.count());
+        Integer maxCoin = result.get(surveyInfo.promotionAmount.max());
+        return OpenSurveyStats.of(count, maxCoin);
     }
 }

--- a/src/main/java/OneQ/OnSurvey/domain/survey/service/query/SurveyQuery.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/service/query/SurveyQuery.java
@@ -4,6 +4,7 @@ import OneQ.OnSurvey.domain.question.model.dto.SectionDto;
 import OneQ.OnSurvey.domain.survey.entity.Survey;
 import OneQ.OnSurvey.domain.survey.model.SurveyStatus;
 import OneQ.OnSurvey.domain.survey.model.dto.OngoingSurveyStats;
+import OneQ.OnSurvey.domain.survey.model.dto.OpenSurveyStats;
 import OneQ.OnSurvey.domain.survey.model.dto.ScreeningViewData;
 import OneQ.OnSurvey.domain.survey.model.dto.SurveyDetailData;
 import OneQ.OnSurvey.domain.survey.model.dto.SurveyListView;
@@ -47,6 +48,7 @@ public interface SurveyQuery {
     // 외부 PORT
     Page<SurveyListView> getPagedSurveyListViewByQuery(Pageable pageable, SurveySearchQuery query);
     List<OngoingSurveyStats> getOngoingSurveyStats();
+    OpenSurveyStats getOpenSurveyStats();
     SurveyDetailData getSurveyDetailById(Long surveyId);
     ScreeningViewData getScreeningIntroBySurveyId(Long surveyId);
     List<SectionDto> getSectionDtoListBySurveyId(Long surveyId);

--- a/src/main/java/OneQ/OnSurvey/domain/survey/service/query/SurveyQueryService.java
+++ b/src/main/java/OneQ/OnSurvey/domain/survey/service/query/SurveyQueryService.java
@@ -17,6 +17,7 @@ import OneQ.OnSurvey.domain.survey.model.Gender;
 import OneQ.OnSurvey.domain.survey.model.Residence;
 import OneQ.OnSurvey.domain.survey.model.SurveyStatus;
 import OneQ.OnSurvey.domain.survey.model.dto.OngoingSurveyStats;
+import OneQ.OnSurvey.domain.survey.model.dto.OpenSurveyStats;
 import OneQ.OnSurvey.domain.survey.model.dto.ScreeningIntroData;
 import OneQ.OnSurvey.domain.survey.model.dto.ScreeningViewData;
 import OneQ.OnSurvey.domain.survey.model.dto.SurveyDetailData;
@@ -530,5 +531,10 @@ public class SurveyQueryService implements SurveyQuery {
     @Override
     public List<OngoingSurveyStats> getOngoingSurveyStats() {
         return surveyRepository.findOngoingSurveys();
+    }
+
+    @Override
+    public OpenSurveyStats getOpenSurveyStats() {
+        return surveyRepository.findOpenSurveyStats();
     }
 }


### PR DESCRIPTION
### ✨ Related Issue

[OMF-337 열려있는 설문 수 및 최고 참여 보상 코인 조회 API 추가](https://onsurvey.atlassian.net/browse/OMF-337)

---

### 📌 Task Details

- [x] `GET /v1/surveys/open-stats` 엔드포인트 추가 (인증 불필요)
- [x] `SurveyRepository`에 ONGOING 설문 수 및 최대 `promotionAmount` 단일 쿼리 추가 (QueryDSL)
- [x] `OpenSurveyStats` DTO 및 `OpenSurveyStatsResponse` 응답 객체 추가
- [x] `SurveyQuery` 인터페이스 및 `SurveyQueryService` 구현체에 `getOpenSurveyStats()` 추가

**응답 예시**
```json
{
  "openSurveyCount": 12,
  "maxRewardCoin": 500
}
```

- `openSurveyCount`: 현재 `ONGOING` 상태인 설문 수
- `maxRewardCoin`: `ONGOING` 설문 중 가장 높은 `promotionAmount` (설문이 없으면 `0`)

---

### 💬 Review Requirements (Optional)

- `survey`와 `survey_info`를 LEFT JOIN 후 집계함수(`COUNT`, `MAX`)를 단일 쿼리로 처리하여 추가 DB 조회 없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 개방된 설문 통계를 조회하는 새로운 API 엔드포인트(`GET /v1/surveys/open-stats`)가 추가되었습니다. 이 엔드포인트는 현재 진행 중인 설문 수와 최대 보상 코인 정보를 조회합니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/On-Survey/Backend/pull/154)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->