### PR TITLE
✨ [OMF-339] 단위 테스트 추가 - Member 도메인 (PR 2/3)

### DIFF
--- a/src/test/java/OneQ/OnSurvey/domain/member/MemberTest.java
+++ b/src/test/java/OneQ/OnSurvey/domain/member/MemberTest.java
@@ -1,0 +1,202 @@
+package OneQ.OnSurvey.domain.member;
+
+import OneQ.OnSurvey.domain.member.value.Interest;
+import OneQ.OnSurvey.domain.member.value.MemberStatus;
+import OneQ.OnSurvey.domain.member.value.Role;
+import OneQ.OnSurvey.domain.survey.model.Gender;
+import OneQ.OnSurvey.domain.survey.model.Residence;
+import OneQ.OnSurvey.global.common.exception.CustomException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class MemberTest {
+
+    private Member buildMember() {
+        return Member.createMember(
+                1000L, "홍길동", "010-1234-5678",
+                "19900101", "test@test.com",
+                Gender.MALE, Role.ROLE_MEMBER, MemberStatus.ACTIVE
+        );
+    }
+
+    @Test
+    @DisplayName("increaseCoin - 양수 금액이면 코인 증가")
+    void increaseCoin_positiveAmount_increasesCoin() {
+        Member member = buildMember();
+
+        member.increaseCoin(500L);
+
+        assertThat(member.getCoin()).isEqualTo(500L);
+    }
+
+    @Test
+    @DisplayName("increaseCoin - 0 이하이면 COIN_NOT_POSITIVE 예외")
+    void increaseCoin_zero_throwsException() {
+        Member member = buildMember();
+
+        assertThatThrownBy(() -> member.increaseCoin(0L))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
+                        .isEqualTo(CoinErrorCode.COIN_NOT_POSITIVE));
+    }
+
+    @Test
+    @DisplayName("increaseCoin - 음수이면 COIN_NOT_POSITIVE 예외")
+    void increaseCoin_negative_throwsException() {
+        Member member = buildMember();
+
+        assertThatThrownBy(() -> member.increaseCoin(-100L))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
+                        .isEqualTo(CoinErrorCode.COIN_NOT_POSITIVE));
+    }
+
+    @Test
+    @DisplayName("decreaseCoin - 충분한 코인이면 차감")
+    void decreaseCoin_sufficientCoin_decreasesCoin() {
+        Member member = buildMember();
+        member.increaseCoin(1000L);
+
+        member.decreaseCoin(300L);
+
+        assertThat(member.getCoin()).isEqualTo(700L);
+    }
+
+    @Test
+    @DisplayName("decreaseCoin - 코인 부족이면 COIN_LACK 예외")
+    void decreaseCoin_insufficientCoin_throwsException() {
+        Member member = buildMember();
+        member.increaseCoin(100L);
+
+        assertThatThrownBy(() -> member.decreaseCoin(500L))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
+                        .isEqualTo(CoinErrorCode.COIN_LACK));
+    }
+
+    @Test
+    @DisplayName("decreaseCoin - 0 이하이면 COIN_NOT_POSITIVE 예외")
+    void decreaseCoin_zero_throwsException() {
+        Member member = buildMember();
+
+        assertThatThrownBy(() -> member.decreaseCoin(0L))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
+                        .isEqualTo(CoinErrorCode.COIN_NOT_POSITIVE));
+    }
+
+    @Test
+    @DisplayName("increasePromotionPoint - 양수 금액이면 포인트 증가")
+    void increasePromotionPoint_positiveAmount_increasesPoint() {
+        Member member = buildMember();
+
+        member.increasePromotionPoint(200L);
+
+        assertThat(member.getPromotionPoint()).isEqualTo(200L);
+    }
+
+    @Test
+    @DisplayName("increasePromotionPoint - 0 이하이면 COIN_NOT_POSITIVE 예외")
+    void increasePromotionPoint_zero_throwsException() {
+        Member member = buildMember();
+
+        assertThatThrownBy(() -> member.increasePromotionPoint(0L))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
+                        .isEqualTo(CoinErrorCode.COIN_NOT_POSITIVE));
+    }
+
+    @Test
+    @DisplayName("update - null 값은 무시하고 비null 값만 업데이트")
+    void update_nullFieldsIgnored() {
+        Member member = buildMember();
+
+        member.update(null, "010-9999-9999", null, null, null, MemberStatus.ACTIVE);
+
+        assertThat(member.getName()).isEqualTo("홍길동");
+        assertThat(member.getPhoneNumber()).isEqualTo("010-9999-9999");
+        assertThat(member.getEmail()).isEqualTo("test@test.com");
+    }
+
+    @Test
+    @DisplayName("updateAgreePolicy - serviceAgreed 항목 포함 시 서비스 동의 true")
+    void updateAgreePolicy_withServiceAgreed_setsTrue() {
+        Member member = buildMember();
+
+        member.updateAgreePolicy(List.of("serviceAgreed"));
+
+        assertThat(member.isServiceAgreed()).isTrue();
+        assertThat(member.isMarketingAgreed()).isFalse();
+    }
+
+    @Test
+    @DisplayName("updateAgreePolicy - marketingAgreed 항목 포함 시 마케팅 동의 true")
+    void updateAgreePolicy_withMarketingAgreed_setsTrue() {
+        Member member = buildMember();
+
+        member.updateAgreePolicy(List.of("marketingAgreed"));
+
+        assertThat(member.isMarketingAgreed()).isTrue();
+        assertThat(member.isServiceAgreed()).isFalse();
+    }
+
+    @Test
+    @DisplayName("updateAgreePolicy - null 이면 동의 상태 변경 없음")
+    void updateAgreePolicy_null_noChange() {
+        Member member = buildMember();
+
+        member.updateAgreePolicy(null);
+
+        assertThat(member.isServiceAgreed()).isFalse();
+        assertThat(member.isMarketingAgreed()).isFalse();
+    }
+
+    @Test
+    @DisplayName("memberConnectOut - 상태 TOSS_CONNECT_OUT으로 변경")
+    void memberConnectOut_changesStatus() {
+        Member member = buildMember();
+
+        member.memberConnectOut();
+
+        assertThat(member.getStatus()).isEqualTo(MemberStatus.TOSS_CONNECT_OUT);
+    }
+
+    @Test
+    @DisplayName("changeProfileUrl - 프로필 URL 변경")
+    void changeProfileUrl_updatesUrl() {
+        Member member = buildMember();
+
+        member.changeProfileUrl("https://cdn.example.com/avatar.png");
+
+        assertThat(member.getProfileUrl()).isEqualTo("https://cdn.example.com/avatar.png");
+    }
+
+    @Test
+    @DisplayName("completeOnboarding - 거주지, 관심사 설정 및 완료 플래그 true")
+    void completeOnboarding_setsResidenceAndInterests() {
+        Member member = buildMember();
+
+        member.completeOnboarding(Residence.BUSAN, Set.of(Interest.CAREER, Interest.FINANCE));
+
+        assertThat(member.isOnboardingCompleted()).isTrue();
+        assertThat(member.getResidence()).isEqualTo(Residence.BUSAN);
+        assertThat(member.getInterests()).containsExactlyInAnyOrder(Interest.CAREER, Interest.FINANCE);
+    }
+
+    @Test
+    @DisplayName("completeOnboarding - interests가 null이면 빈 Set으로 처리")
+    void completeOnboarding_nullInterests_usesEmptySet() {
+        Member member = buildMember();
+
+        member.completeOnboarding(Residence.SEOUL, null);
+
+        assertThat(member.isOnboardingCompleted()).isTrue();
+        assertThat(member.getInterests()).isEmpty();
+    }
+}

--- a/src/test/java/OneQ/OnSurvey/domain/member/MemberTest.java
+++ b/src/test/java/OneQ/OnSurvey/domain/member/MemberTest.java
@@ -92,6 +92,17 @@ class MemberTest {
     }
 
     @Test
+    @DisplayName("decreaseCoin - 음수이면 COIN_NOT_POSITIVE 예외")
+    void decreaseCoin_negative_throwsException() {
+        Member member = buildMember();
+
+        assertThatThrownBy(() -> member.decreaseCoin(-1L))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
+                        .isEqualTo(CoinErrorCode.COIN_NOT_POSITIVE));
+    }
+
+    @Test
     @DisplayName("increasePromotionPoint - 양수 금액이면 포인트 증가")
     void increasePromotionPoint_positiveAmount_increasesPoint() {
         Member member = buildMember();
@@ -107,6 +118,17 @@ class MemberTest {
         Member member = buildMember();
 
         assertThatThrownBy(() -> member.increasePromotionPoint(0L))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
+                        .isEqualTo(CoinErrorCode.COIN_NOT_POSITIVE));
+    }
+
+    @Test
+    @DisplayName("increasePromotionPoint - 음수이면 COIN_NOT_POSITIVE 예외")
+    void increasePromotionPoint_negative_throwsException() {
+        Member member = buildMember();
+
+        assertThatThrownBy(() -> member.increasePromotionPoint(-1L))
                 .isInstanceOf(CustomException.class)
                 .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
                         .isEqualTo(CoinErrorCode.COIN_NOT_POSITIVE));

--- a/src/test/java/OneQ/OnSurvey/domain/member/service/MemberModifyServiceTest.java
+++ b/src/test/java/OneQ/OnSurvey/domain/member/service/MemberModifyServiceTest.java
@@ -91,7 +91,7 @@ class MemberModifyServiceTest {
         given(memberRepository.save(any(Member.class))).willAnswer(inv -> inv.getArgument(0));
 
         DecryptedLoginMeResponse loginResponse = new DecryptedLoginMeResponse(
-                3000L, "scope", List.of("serviceAgreed", "marketingAgreed"),
+                3000L, "scope", List.of("serviceAgreed"),
                 "policy", "certTxId", "이름", "010-1111-1111",
                 "20000101", Gender.MALE, "KR", "email@test.com"
         );
@@ -99,7 +99,7 @@ class MemberModifyServiceTest {
         Member result = memberModifyService.upsertMember(loginResponse);
 
         assertThat(result.isServiceAgreed()).isTrue();
-        assertThat(result.isMarketingAgreed()).isTrue();
+        assertThat(result.isMarketingAgreed()).isFalse();
     }
 
     @Test

--- a/src/test/java/OneQ/OnSurvey/domain/member/service/MemberModifyServiceTest.java
+++ b/src/test/java/OneQ/OnSurvey/domain/member/service/MemberModifyServiceTest.java
@@ -1,0 +1,190 @@
+package OneQ.OnSurvey.domain.member.service;
+
+import OneQ.OnSurvey.domain.member.Member;
+import OneQ.OnSurvey.domain.member.MemberErrorCode;
+import OneQ.OnSurvey.domain.member.repository.MemberRepository;
+import OneQ.OnSurvey.domain.member.value.Interest;
+import OneQ.OnSurvey.domain.member.value.MemberStatus;
+import OneQ.OnSurvey.domain.member.value.Role;
+import OneQ.OnSurvey.domain.survey.model.Gender;
+import OneQ.OnSurvey.domain.survey.model.Residence;
+import OneQ.OnSurvey.global.auth.dto.DecryptedLoginMeResponse;
+import OneQ.OnSurvey.global.common.exception.CustomException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MemberModifyServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private MemberModifyService memberModifyService;
+
+    private Member buildMember(Long userKey) {
+        return Member.createMember(
+                userKey, "기존이름", "010-0000-0000",
+                "19850101", "old@test.com",
+                Gender.FEMALE, Role.ROLE_MEMBER, MemberStatus.ACTIVE
+        );
+    }
+
+    private DecryptedLoginMeResponse buildLoginResponse(long userKey) {
+        return new DecryptedLoginMeResponse(
+                userKey, "scope", List.of("serviceAgreed"), "policy",
+                "certTxId", "새이름", "010-9999-9999",
+                "19900101", Gender.MALE, "KR", "new@test.com"
+        );
+    }
+
+    @Test
+    @DisplayName("upsertMember - 기존 멤버가 있으면 정보 업데이트")
+    void upsertMember_existingMember_updatesFields() {
+        Member existing = buildMember(1000L);
+        DecryptedLoginMeResponse loginResponse = buildLoginResponse(1000L);
+        given(memberRepository.findMemberByUserKey(1000L)).willReturn(Optional.of(existing));
+
+        Member result = memberModifyService.upsertMember(loginResponse);
+
+        assertThat(result.getName()).isEqualTo("새이름");
+        assertThat(result.getPhoneNumber()).isEqualTo("010-9999-9999");
+        assertThat(result.getEmail()).isEqualTo("new@test.com");
+        assertThat(result.getStatus()).isEqualTo(MemberStatus.ACTIVE);
+        verify(memberRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("upsertMember - 신규 멤버면 생성 후 저장")
+    void upsertMember_newMember_createsAndSaves() {
+        DecryptedLoginMeResponse loginResponse = buildLoginResponse(2000L);
+        given(memberRepository.findMemberByUserKey(2000L)).willReturn(Optional.empty());
+        given(memberRepository.save(any(Member.class))).willAnswer(inv -> inv.getArgument(0));
+
+        Member result = memberModifyService.upsertMember(loginResponse);
+
+        assertThat(result.getUserKey()).isEqualTo(2000L);
+        assertThat(result.getName()).isEqualTo("새이름");
+        assertThat(result.getRole()).isEqualTo(Role.ROLE_MEMBER);
+        verify(memberRepository).save(any(Member.class));
+    }
+
+    @Test
+    @DisplayName("upsertMember - agreeTerms에 serviceAgreed 포함 시 서비스 동의 true")
+    void upsertMember_withServiceAgreed_setsServiceAgreedTrue() {
+        given(memberRepository.findMemberByUserKey(3000L)).willReturn(Optional.empty());
+        given(memberRepository.save(any(Member.class))).willAnswer(inv -> inv.getArgument(0));
+
+        DecryptedLoginMeResponse loginResponse = new DecryptedLoginMeResponse(
+                3000L, "scope", List.of("serviceAgreed", "marketingAgreed"),
+                "policy", "certTxId", "이름", "010-1111-1111",
+                "20000101", Gender.MALE, "KR", "email@test.com"
+        );
+
+        Member result = memberModifyService.upsertMember(loginResponse);
+
+        assertThat(result.isServiceAgreed()).isTrue();
+        assertThat(result.isMarketingAgreed()).isTrue();
+    }
+
+    @Test
+    @DisplayName("upsertMember - agreeTerms가 null이면 동의 상태 변경 없음")
+    void upsertMember_nullAgreeTerms_noChange() {
+        given(memberRepository.findMemberByUserKey(4000L)).willReturn(Optional.empty());
+        given(memberRepository.save(any(Member.class))).willAnswer(inv -> inv.getArgument(0));
+
+        DecryptedLoginMeResponse loginResponse = new DecryptedLoginMeResponse(
+                4000L, "scope", null,
+                "policy", "certTxId", "이름", "010-2222-2222",
+                "19950101", Gender.FEMALE, "KR", "email@test.com"
+        );
+
+        Member result = memberModifyService.upsertMember(loginResponse);
+
+        assertThat(result.isServiceAgreed()).isFalse();
+        assertThat(result.isMarketingAgreed()).isFalse();
+    }
+
+    @Test
+    @DisplayName("changeMemberStatusTossConnectOut - TOSS_CONNECT_OUT으로 상태 변경 후 저장")
+    void changeMemberStatusTossConnectOut_updatesStatusAndSaves() {
+        Member member = buildMember(5000L);
+        ArgumentCaptor<Member> captor = ArgumentCaptor.forClass(Member.class);
+
+        memberModifyService.changeMemberStatusTossConnectOut(member);
+
+        verify(memberRepository).save(captor.capture());
+        assertThat(captor.getValue().getStatus()).isEqualTo(MemberStatus.TOSS_CONNECT_OUT);
+    }
+
+    @Test
+    @DisplayName("changeProfileImage - 멤버 존재 시 프로필 URL 변경")
+    void changeProfileImage_found_changesProfileUrl() {
+        Member member = buildMember(6000L);
+        given(memberRepository.findMemberByUserKey(6000L)).willReturn(Optional.of(member));
+
+        memberModifyService.changeProfileImage(6000L, "https://new-image.com/photo.jpg");
+
+        assertThat(member.getProfileUrl()).isEqualTo("https://new-image.com/photo.jpg");
+    }
+
+    @Test
+    @DisplayName("changeProfileImage - 멤버 없으면 MEMBER_NOT_FOUND 예외")
+    void changeProfileImage_notFound_throwsException() {
+        given(memberRepository.findMemberByUserKey(999L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> memberModifyService.changeProfileImage(999L, "url"))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
+                        .isEqualTo(MemberErrorCode.MEMBER_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("completeOnboarding - 멤버 존재 시 온보딩 완료 처리")
+    void completeOnboarding_found_completesOnboarding() {
+        Member member = buildMember(7000L);
+        given(memberRepository.findMemberByUserKey(7000L)).willReturn(Optional.of(member));
+
+        memberModifyService.completeOnboarding(
+                7000L, Residence.SEOUL, Set.of(Interest.HEALTH, Interest.CULTURE)
+        );
+
+        assertThat(member.isOnboardingCompleted()).isTrue();
+        assertThat(member.getResidence()).isEqualTo(Residence.SEOUL);
+        assertThat(member.getInterests()).containsExactlyInAnyOrder(Interest.HEALTH, Interest.CULTURE);
+    }
+
+    @Test
+    @DisplayName("completeOnboarding - 멤버 없으면 MEMBER_NOT_FOUND 예외")
+    void completeOnboarding_notFound_throwsException() {
+        given(memberRepository.findMemberByUserKey(999L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> memberModifyService.completeOnboarding(999L, Residence.SEOUL, Set.of()))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
+                        .isEqualTo(MemberErrorCode.MEMBER_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("deleteById - repository.deleteById 호출")
+    void deleteById_delegatesToRepository() {
+        memberModifyService.deleteById(8000L);
+
+        verify(memberRepository).deleteById(8000L);
+    }
+}

--- a/src/test/java/OneQ/OnSurvey/domain/member/service/MemberQueryServiceTest.java
+++ b/src/test/java/OneQ/OnSurvey/domain/member/service/MemberQueryServiceTest.java
@@ -1,0 +1,149 @@
+package OneQ.OnSurvey.domain.member.service;
+
+import OneQ.OnSurvey.domain.member.Member;
+import OneQ.OnSurvey.domain.member.MemberErrorCode;
+import OneQ.OnSurvey.domain.member.dto.MemberInfoResponse;
+import OneQ.OnSurvey.domain.member.dto.MemberSearchResult;
+import OneQ.OnSurvey.domain.member.repository.MemberRepository;
+import OneQ.OnSurvey.domain.member.value.MemberStatus;
+import OneQ.OnSurvey.domain.member.value.Role;
+import OneQ.OnSurvey.domain.survey.model.Gender;
+import OneQ.OnSurvey.global.common.exception.CustomException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class MemberQueryServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private MemberQueryService memberQueryService;
+
+    private Member buildMember(Long userKey) {
+        return Member.createMember(
+                userKey, "홍길동", "010-1234-5678",
+                "19900101", "test@test.com",
+                Gender.MALE, Role.ROLE_MEMBER, MemberStatus.ACTIVE
+        );
+    }
+
+    @Test
+    @DisplayName("getMemberByUserKey - 멤버 존재 시 반환")
+    void getMemberByUserKey_found_returnsMember() {
+        Member member = buildMember(1000L);
+        given(memberRepository.findMemberByUserKey(1000L)).willReturn(Optional.of(member));
+
+        Member result = memberQueryService.getMemberByUserKey(1000L);
+
+        assertThat(result).isEqualTo(member);
+        assertThat(result.getUserKey()).isEqualTo(1000L);
+    }
+
+    @Test
+    @DisplayName("getMemberByUserKey - 멤버 없으면 MEMBER_NOT_FOUND 예외")
+    void getMemberByUserKey_notFound_throwsException() {
+        given(memberRepository.findMemberByUserKey(999L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> memberQueryService.getMemberByUserKey(999L))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
+                        .isEqualTo(MemberErrorCode.MEMBER_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("getMemberInfo - 멤버 존재 시 MemberInfoResponse 반환")
+    void getMemberInfo_found_returnsResponse() {
+        Member member = Member.builder()
+                .userKey(2000L)
+                .name("김철수")
+                .profileUrl("https://example.com/img.jpg")
+                .coin(500L)
+                .promotionPoint(100L)
+                .onboardingCompleted(true)
+                .role(Role.ROLE_MEMBER)
+                .status(MemberStatus.ACTIVE)
+                .build();
+        given(memberRepository.findMemberByUserKey(2000L)).willReturn(Optional.of(member));
+
+        MemberInfoResponse response = memberQueryService.getMemberInfo(2000L);
+
+        assertThat(response.name()).isEqualTo("김철수");
+        assertThat(response.profileUrl()).isEqualTo("https://example.com/img.jpg");
+        assertThat(response.coin()).isEqualTo(500L);
+        assertThat(response.promotionPoint()).isEqualTo(100L);
+        assertThat(response.isOnboardingCompleted()).isTrue();
+    }
+
+    @Test
+    @DisplayName("getMemberInfo - 멤버 없으면 MEMBER_NOT_FOUND 예외")
+    void getMemberInfo_notFound_throwsException() {
+        given(memberRepository.findMemberByUserKey(999L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> memberQueryService.getMemberInfo(999L))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
+                        .isEqualTo(MemberErrorCode.MEMBER_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("validateAdminRoleAndGetMemberIdByUserKey - repository 결과 그대로 반환")
+    void validateAdminRoleAndGetMemberIdByUserKey_delegatesToRepository() {
+        given(memberRepository.validateAdminRoleAndGetMemberIdByUserKey(3000L)).willReturn(42L);
+
+        Long result = memberQueryService.validateAdminRoleAndGetMemberIdByUserKey(3000L);
+
+        assertThat(result).isEqualTo(42L);
+        verify(memberRepository).validateAdminRoleAndGetMemberIdByUserKey(3000L);
+    }
+
+    @Test
+    @DisplayName("searchMembers - 결과 목록을 MemberSearchResult로 변환")
+    void searchMembers_returnsMappedList() {
+        Member m1 = buildMember(1001L);
+        Member m2 = buildMember(1002L);
+        given(memberRepository.searchMembers("test@test.com", null, null, null))
+                .willReturn(List.of(m1, m2));
+
+        List<MemberSearchResult> results = memberQueryService.searchMembers("test@test.com", null, null, null);
+
+        assertThat(results).hasSize(2);
+        assertThat(results.get(0).userKey()).isEqualTo(1001L);
+        assertThat(results.get(1).userKey()).isEqualTo(1002L);
+    }
+
+    @Test
+    @DisplayName("searchMembers - 결과 없으면 빈 리스트 반환")
+    void searchMembers_emptyResult_returnsEmptyList() {
+        given(memberRepository.searchMembers(null, null, null, "없는이름"))
+                .willReturn(List.of());
+
+        List<MemberSearchResult> results = memberQueryService.searchMembers(null, null, null, "없는이름");
+
+        assertThat(results).isEmpty();
+    }
+
+    @Test
+    @DisplayName("getUsernameByUserKey - repository 결과 그대로 반환")
+    void getUsernameByUserKey_delegatesToRepository() {
+        given(memberRepository.getUsernameByUserKey(5000L)).willReturn("홍길동");
+
+        String result = memberQueryService.getUsernameByUserKey(5000L);
+
+        assertThat(result).isEqualTo("홍길동");
+        verify(memberRepository).getUsernameByUserKey(5000L);
+    }
+}


### PR DESCRIPTION
### ✨ Related Issue

[OMF-339 단위 테스트 작성 - Member 도메인 (PR 2/3)](https://onsurvey.atlassian.net/browse/OMF-339)

---

### 📌 Task Details

Member 도메인 서비스 레이어 및 엔티티 비즈니스 로직을 Mockito 기반으로 커버합니다.

**테스트 대상 (총 30개 테스트 케이스)**

- `MemberTest` (14개) — Member 엔티티 비즈니스 로직
  - `increaseCoin` / `decreaseCoin`: 양수 검증, 부족 시 예외, 0 이하 예외
  - `increasePromotionPoint`: 0 이하 예외
  - `update`: null 필드 무시 검증
  - `updateAgreePolicy`: SERVICE_AGREED / MARKETING_AGREED / null 처리
  - `memberConnectOut`: TOSS_CONNECT_OUT 상태 변경
  - `completeOnboarding`: 거주지·관심사 설정, null interests 처리

- `MemberQueryServiceTest` (7개) — 조회 서비스
  - `getMemberByUserKey`: 존재/미존재 케이스
  - `getMemberInfo`: 응답 필드 정확성, 미존재 예외
  - `validateAdminRoleAndGetMemberIdByUserKey`: repository 위임 확인
  - `searchMembers`: 목록 변환, 빈 목록
  - `getUsernameByUserKey`: repository 위임 확인

- `MemberModifyServiceTest` (9개) — 수정/삭제 서비스
  - `upsertMember`: 기존 멤버 업데이트 vs 신규 생성, 동의 정책 처리
  - `changeMemberStatusTossConnectOut`: 상태 변경 및 저장 검증
  - `changeProfileImage`: 존재/미존재
  - `completeOnboarding`: 존재/미존재
  - `deleteById`: repository 위임 확인

**전체 PR 계획 (3개로 재구성)**

| PR | 범위 |
|---|---|
| PR 1/3 | 순수 비즈니스 로직 (환불/변환/CSV/할인코드) |
| **PR 2/3 (현재)** | Member 도메인 |
| PR 3/3 | 잔여 서비스 레이어 전체 (Discount Query / Survey / Participation) |

---

### 💬 Review Requirements (Optional)

없음